### PR TITLE
fix default image doesn't match symbol and hü values pre-selected

### DIFF
--- a/prototype/index.html
+++ b/prototype/index.html
@@ -141,6 +141,7 @@
         }
 
         function doThings(icon, hue) {
+            console.log(icon)
             const canvas = document.getElementById("main");
             const ctx = canvas.getContext('2d');
 
@@ -173,6 +174,7 @@
         function generate() {
             const symbol = document.getElementById("symbol").value;
             const hue = document.getElementById("hue").value;
+            console.log(symbol)
             doThings(String.fromCodePoint(parseInt(symbol, 16)), hue);
         }
 
@@ -193,7 +195,7 @@
             versionNumber = version;
             versionType = edition;
 
-            doThings('\u{f8e9}', 0);
+            doThings('\u{f013}', 216);
 
             document.getElementById('fontawesome-version').innerHTML = `FontAwesome ${versionNumber} ${versionType}`
             document.getElementById('main-tool').style.display = 'block';
@@ -203,7 +205,6 @@
         document.getElementById('main-tool').style.display = 'none';
         document.fonts.ready.then(() => {
             console.log(document.fonts.check("900 16px 'Font Awesome 5 Pro'") ? "Pro is available" : "Pro is unavailable.");
-            doThings('\u{f8e9}', 0)
         });
     </script>
 </body>

--- a/prototype/index.html
+++ b/prototype/index.html
@@ -6,7 +6,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Stream Awesome - The Stream Deck Icon Generator using Font Awesome</title>
-    <link rel="stylesheet" href="fontawesome/css/all.css">
+    <link rel="stylesheet" href="fontawesome2/css/all.css">
     <style type="text/css">
         body {
             background: #222;
@@ -141,7 +141,6 @@
         }
 
         function doThings(icon, hue) {
-            console.log(icon)
             const canvas = document.getElementById("main");
             const ctx = canvas.getContext('2d');
 
@@ -174,7 +173,6 @@
         function generate() {
             const symbol = document.getElementById("symbol").value;
             const hue = document.getElementById("hue").value;
-            console.log(symbol)
             doThings(String.fromCodePoint(parseInt(symbol, 16)), hue);
         }
 

--- a/prototype/index.html
+++ b/prototype/index.html
@@ -6,7 +6,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Stream Awesome - The Stream Deck Icon Generator using Font Awesome</title>
-    <link rel="stylesheet" href="fontawesome2/css/all.css">
+    <link rel="stylesheet" href="fontawesome/css/all.css">
     <style type="text/css">
         body {
             background: #222;


### PR DESCRIPTION
This is an important change for free edition as you can see in the image for before. 

This changes the initial image to show the icon `f013` which was specified in symbol text are. Additionally, the color was changed to the value `216` which is the position of the slider.

Before:
![image](https://user-images.githubusercontent.com/26039509/229361497-646b6950-50ea-484e-8236-cf162e9168e9.png)

After: 
![image](https://user-images.githubusercontent.com/26039509/229361457-f5f466cf-5f25-4f2c-bf40-31a7bdc8f923.png)
