### PR TITLE
Add detection of used version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
 # Stream Awesome - Stream Deck Icon Generator using Font Awesome
 
-Generate awesome looking stream deck icons like [these](https://www.instagram.com/p/CKPCM_YF16a/). Close to the [Elgato original](https://www.elgato.com/stream-deck) and of course awesome because of [Font Awesome](https://fontawesome.com/). Currently in prototyping phase.
+Generate awesome looking stream deck icons like [these](https://www.instagram.com/p/CKPCM_YF16a/). Close to the [Elgato original](https://www.elgato.com/stream-deck) and of course awesome because of [Font Awesome](https://fontawesome.com/). Currently, in prototyping phase.
+![image](https://instagram.fham6-1.fna.fbcdn.net/v/t51.2885-15/140034101_700414367324593_263691442762893319_n.jpg?stp=dst-jpg_e35&_nc_ht=instagram.fham6-1.fna.fbcdn.net&_nc_ohc=D6xxHklJaO8AX-gkDnR&edm=ALQROFkBAAAA&ccb=7-5&oh=00_AfAsXG2ZNZISVMFyQAncR_ZZEJSIv-zdZLWDYFH7Q2-h2w&oe=642E15F8)
+
+## How to install
+1. Clone the repository
+2. Download [Font Awesome for the web](https://fontawesome.com/download) 5.6.0 or higher
+3. Extract the folder in `prototype` directory of cloned repository
+4. Rename extracted folder to `fontawesome`
+5. Open `prototype/index.html` in your favorite browser

--- a/prototype/index.html
+++ b/prototype/index.html
@@ -214,13 +214,12 @@
             console.log(onlyInstalled)
             const response = await fetch("https://api.github.com/repos/FortAwesome/Font-Awesome/tags", {method: 'GET'});
             response.json().then(data => {
-                let selected = true;
                 const allVersions = [];
-                const versionElement = document.getElementById("version");
-                versionElement.innerHTML = "";
+                const versionElement = document.getElementById('version');
+                versionElement.innerHTML = '';
                 for (let i = 0; i < data.length; i++) {
-                    let optionElement = document.createElement("option");
-                    const versionNumber = data[i].name.replace('v', '');
+                    let optionElement = document.createElement('option');
+                    const versionNumber = data[i].name.replace('v', ''); // some early version tags have "v" as prefix
                     if (!onlyInstalled || (document.fonts.check(`900 16px 'Font Awesome ${versionNumber.split(".")[0]} Free'`)
                     || document.fonts.check(`900 16px 'Font Awesome ${versionNumber.split(".")[0]} Pro'`))) {
                         optionElement.value = versionNumber;
@@ -239,9 +238,10 @@
                     }
                     return 0;
                 }).reverse();
+                let selected = true;
                 for (let i = 0; i < allVersions.length; i++) {
                     let version = allVersions[i];
-                    if (selected) {
+                    if (selected) { // select first value
                         version.selected = selected;
                         selected = false;
                     }

--- a/prototype/index.html
+++ b/prototype/index.html
@@ -45,14 +45,9 @@
         <p style="font-size: 26px">Select your Font Awesome version</p>
         <p>
             <label for="version">Version: </label>
-            <select id="version">
-                <option value="6">6</option>
-                <option value="5" selected>5</option>
-                <option value="4">4</option>
-                <option value="3">3</option>
-                <option value="2">2</option>
-                <option value="1">1</option>
-            </select>
+            <select id="version"></select>
+            <input type="checkbox" id="only-installed" checked="checked" onchange="getVersions(this.checked)">
+            <label for="only-installed">Show only installed</label>
         </p>
 
         <p>
@@ -94,6 +89,7 @@
     </div>
 
     <script>
+        let exactVersionNumber = '6.4.0';
         let versionNumber = '6';
         let versionType = 'Free';
         // TODO: Add text
@@ -138,16 +134,15 @@
                 headers: {
                     'Content-Type': 'application/json'
                 },
-                body: JSON.stringify({ "query": `{ search(version: \"5.15.4\", query: \"${searchString}\", first: 30) {id\nlabel\nunicode\nmembership { free\npro } } }` }
-                )
+                body: JSON.stringify({ "query": `{ search(version: \"${exactVersionNumber}\", query: \"${searchString}\", first: 30) {id\nlabel\nunicode\nmembership { ${versionType === 'Free' ? 'free' : 'free\npro'} } } }` })
             });
             return response.json();
         }
 
         function download() {
-            var canvas = document.getElementById("main");
-            image = canvas.toDataURL("image/png").replace("image/png", "image/octet-stream");
-            var link = document.createElement('a');
+            let canvas = document.getElementById("main");
+            const image = canvas.toDataURL("image/png").replace("image/png", "image/octet-stream");
+            let link = document.createElement('a');
             link.download = `stream-awesome-icon-${Math.round(Math.random() * 100000)}.png`;
             link.href = image;
             link.click();
@@ -190,9 +185,10 @@
         }
 
         function start() {
-            var dropdown = document.getElementById('version');
-            var option = dropdown.options[dropdown.selectedIndex];
-            const version = option.value;
+            let dropdown = document.getElementById('version');
+            let option = dropdown.options[dropdown.selectedIndex];
+            const exactVersion = option.value;
+            const version = exactVersion.split(".")[0]
 
             dropdown = document.getElementById('edition');
             option = dropdown.options[dropdown.selectedIndex];
@@ -203,6 +199,7 @@
                 document.getElementById('warning').innerHTML = `${font} not available!`
                 return;
             }
+            exactVersionNumber = exactVersion;
             versionNumber = version;
             versionType = edition;
 
@@ -213,10 +210,54 @@
             document.getElementById('version-selection').style.display = 'none';
         }
 
+        async function getVersions(onlyInstalled) {
+            console.log(onlyInstalled)
+            const response = await fetch("https://api.github.com/repos/FortAwesome/Font-Awesome/tags", {method: 'GET'});
+            response.json().then(data => {
+                let selected = true;
+                const allVersions = [];
+                const versionElement = document.getElementById("version");
+                versionElement.innerHTML = "";
+                for (let i = 0; i < data.length; i++) {
+                    let optionElement = document.createElement("option");
+                    const versionNumber = data[i].name.replace('v', '');
+                    if (!onlyInstalled || (document.fonts.check(`900 16px 'Font Awesome ${versionNumber.split(".")[0]} Free'`)
+                    || document.fonts.check(`900 16px 'Font Awesome ${versionNumber.split(".")[0]} Pro'`))) {
+                        optionElement.value = versionNumber;
+                        optionElement.text = optionElement.value;
+                        allVersions.push(optionElement);
+                    }
+                }
+                allVersions.sort(function (a, b) {
+                    const vA = a.value.toUpperCase();
+                    const vB = b.value.toUpperCase();
+                    if (vA < vB) {
+                        return -1;
+                    }
+                    if (vA > vB) {
+                        return 1;
+                    }
+                    return 0;
+                }).reverse();
+                for (let i = 0; i < allVersions.length; i++) {
+                    let version = allVersions[i];
+                    if (selected) {
+                        version.selected = selected;
+                        selected = false;
+                    }
+                    versionElement.appendChild(version);
+                }
+            }).catch(error => {
+                console.error(error)
+            })
+        }
+
         document.getElementById('main-tool').style.display = 'none';
         document.fonts.ready.then(() => {
             console.log(document.fonts.check("900 16px 'Font Awesome 5 Pro'") ? "Pro is available" : "Pro is unavailable.");
         });
+
+        getVersions(true);
     </script>
 </body>
 

--- a/prototype/index.html
+++ b/prototype/index.html
@@ -14,6 +14,10 @@
             font-size: 20px;
         }
 
+        body a {
+            color: #f5a80e;
+        }
+
         button {
             font-size: 20px;
         }
@@ -41,51 +45,25 @@
         <i class="fad fa-glasses"></i>
     </div>
 
-    <div id="version-selection">
-        <p style="font-size: 26px">Select your Font Awesome version</p>
-        <p>
-            <label for="version">Version: </label>
-            <select id="version"></select>
-            <input type="checkbox" id="only-installed" checked="checked" onchange="getVersions(this.checked)">
-            <label for="only-installed">Show only installed</label>
+    <p><label id="fontawesome-version"></label></p>
+    <div id="controls">
+        <p><label for="hue">Hü: </label><input type="range" id="hue" max=360 min=0 value=216 oninput="generate()">
         </p>
-
-        <p>
-            <label for="edition">Edition: </label>
-            <select id="edition">
-                <option value="Free">Free</option>
-                <option value="Pro" selected>Pro</option>
-            </select>
-        </p>
-
-        <div>
-            <button autofocus id="start" onclick="start()">Let's go!</button>
-        </div>
-
-        <label id="warning" style="color: red; font-size: 69px"></label>
-
+        <p><label for="symbol">Symbol: </label><input type="text" id="symbol" value="f013"
+                onkeydown="if(event.keyCode === 13) generate()"></p>
+        <button id="generate" onclick="generate()">Generate!</button>
+        <button id="saveImage" onclick="download()">Download!</button>
     </div>
-    <div id="main-tool">
-        <p><label id="fontawesome-version"></label></p>
-        <div id="controls">
-            <p><label for="hue">Hü: </label><input type="range" id="hue" max=360 min=0 value=216 oninput="generate()">
-            </p>
-            <p><label for="symbol">Symbol: </label><input type="text" id="symbol" value="f013"
-                    onkeydown="if(event.keyCode === 13) generate()"></p>
-            <button id="generate" onclick="generate()">Generate!</button>
-            <button id="saveImage" onclick="download()">Download!</button>
-        </div>
 
-        <div id="content">
-            <canvas id="main" width=256 height=256>
-            </canvas>
-        </div>
+    <div id="content">
+        <canvas id="main" width=256 height=256>
+        </canvas>
+    </div>
 
-        <div id="picker">
-            <p><label for="search">Search: </label><input type="text" id="search" onkeydown="if(event.keyCode === 13) searchIcons()"></p>
-            <button id="searchIcons" onclick="searchIcons()">Search!</button>
-            <div id="searchResults"></div>
-        </div>
+    <div id="picker">
+        <p><label for="search">Search: </label><input type="text" id="search" onkeydown="if(event.keyCode === 13) searchIcons()"></p>
+        <button id="searchIcons" onclick="searchIcons()">Search!</button>
+        <div id="searchResults"></div>
     </div>
 
     <script>
@@ -184,80 +162,38 @@
             doThings(String.fromCodePoint(parseInt(symbol, 16)), hue);
         }
 
-        function start() {
-            let dropdown = document.getElementById('version');
-            let option = dropdown.options[dropdown.selectedIndex];
-            const exactVersion = option.value;
-            const version = exactVersion.split(".")[0]
-
-            dropdown = document.getElementById('edition');
-            option = dropdown.options[dropdown.selectedIndex];
-            const edition = option.value;
-
-            const font = `Font Awesome ${version} ${edition}`;
-            if (!document.fonts.check(`900 16px '${font}'`)) {
-                document.getElementById('warning').innerHTML = `${font} not available!`
-                return;
-            }
-            exactVersionNumber = exactVersion;
-            versionNumber = version;
-            versionType = edition;
-
+        async function start() {
+            await getInstalledVersion();
             doThings('\u{f013}', 216);
-
-            document.getElementById('fontawesome-version').innerHTML = `FontAwesome ${versionNumber} ${versionType}`
-            document.getElementById('main-tool').style.display = 'block';
-            document.getElementById('version-selection').style.display = 'none';
+            document.getElementById('fontawesome-version').innerHTML = `FontAwesome ${exactVersionNumber} ${versionType}`
         }
 
-        async function getVersions(onlyInstalled) {
-            console.log(onlyInstalled)
-            const response = await fetch("https://api.github.com/repos/FortAwesome/Font-Awesome/tags", {method: 'GET'});
-            response.json().then(data => {
-                const allVersions = [];
-                const versionElement = document.getElementById('version');
-                versionElement.innerHTML = '';
-                for (let i = 0; i < data.length; i++) {
-                    let optionElement = document.createElement('option');
-                    const versionNumber = data[i].name.replace('v', ''); // some early version tags have "v" as prefix
-                    if (!onlyInstalled || (document.fonts.check(`900 16px 'Font Awesome ${versionNumber.split(".")[0]} Free'`)
-                    || document.fonts.check(`900 16px 'Font Awesome ${versionNumber.split(".")[0]} Pro'`))) {
-                        optionElement.value = versionNumber;
-                        optionElement.text = optionElement.value;
-                        allVersions.push(optionElement);
-                    }
-                }
-                allVersions.sort(function (a, b) {
-                    const vA = a.value.toUpperCase();
-                    const vB = b.value.toUpperCase();
-                    if (vA < vB) {
-                        return -1;
-                    }
-                    if (vA > vB) {
-                        return 1;
-                    }
-                    return 0;
-                }).reverse();
-                let selected = true;
-                for (let i = 0; i < allVersions.length; i++) {
-                    let version = allVersions[i];
-                    if (selected) { // select first value
-                        version.selected = selected;
-                        selected = false;
-                    }
-                    versionElement.appendChild(version);
-                }
-            }).catch(error => {
-                console.error(error)
-            })
+        async function getInstalledVersion() {
+            const pattern = /\d+\.\d+\.\d+/;
+            const link = document.querySelector('link[rel="stylesheet"]');
+
+            const failText = 'Something went wrong. Please have a look at <a href="https://github.com/sebinside/StreamAwesome">StreamAwesome repo</a> for instructions.';
+            if (link) {
+                await fetch(link.href)
+                    .then(response => response.text())
+                    .then(css => {
+                        exactVersionNumber = css.match(pattern)[0];
+                        versionNumber = exactVersionNumber.split(".")[0];
+                        versionType = Array.from(document.fonts).filter(font => font.family.includes("Font Awesome")).find(font => font.family.includes("Pro")) ? 'Pro' : 'Free';
+                    })
+                    .catch(error => {
+                        console.error(error);
+                        document.body.innerHTML = failText;
+                    });
+            } else {
+                document.body.innerHTML = failText;
+            }
         }
 
-        document.getElementById('main-tool').style.display = 'none';
         document.fonts.ready.then(() => {
-            console.log(document.fonts.check("900 16px 'Font Awesome 5 Pro'") ? "Pro is available" : "Pro is unavailable.");
+            start();
         });
 
-        getVersions(true);
     </script>
 </body>
 

--- a/prototype/index.html
+++ b/prototype/index.html
@@ -206,7 +206,7 @@
             versionNumber = version;
             versionType = edition;
 
-            doThings('\u{f8e9}', 0);
+            doThings('\u{f013}', 216);
 
             document.getElementById('fontawesome-version').innerHTML = `FontAwesome ${versionNumber} ${versionType}`
             document.getElementById('main-tool').style.display = 'block';
@@ -216,7 +216,6 @@
         document.getElementById('main-tool').style.display = 'none';
         document.fonts.ready.then(() => {
             console.log(document.fonts.check("900 16px 'Font Awesome 5 Pro'") ? "Pro is available" : "Pro is unavailable.");
-            doThings('\u{f8e9}', 0)
         });
     </script>
 </body>

--- a/prototype/index.html
+++ b/prototype/index.html
@@ -101,22 +101,35 @@
         async function searchIcons() {
             const searchString = document.querySelector("#search").value;
             const result = await callAPI(searchString);
-            const entries = result.data.search.map(entry => [entry.id, entry.unicode]);
 
             document.querySelector("#searchResults").innerHTML = "";
             
-            for (let entry of entries) {
+            for (let entry of result.data.search) {
+                if (versionType === 'Free' && !isAvailableInFree(entry)) {
+                    console.log(`Skipped ${entry[0]}`)
+                    continue;
+                }
+
                 const displayElement = document.createElement('i');
-                displayElement.classList.add("fas");
-                displayElement.classList.add(`fa-${entry[0]}`);
-                displayElement.title = `${entry[0]} (${entry[1]})`;
-                displayElement.onclick = () => {updateSymbol(`${entry[1]}`);generate()};
+                displayElement.classList.add(`${isBrand(entry) ? 'fab' : 'fas'}`);
+                displayElement.classList.add(`fa-${entry.id}`);
+                displayElement.title = `${entry.id} (${entry.unicode})`;
+                displayElement.onclick = () => {updateSymbol(`${entry.unicode}`);generate()};
                 document.querySelector("#searchResults").appendChild(displayElement);
             }
         }
 
         function updateSymbol(symbol) {
             document.querySelector("#symbol").value = symbol;
+        }
+
+        function isAvailableInFree(icon) {
+            // Only brands and solids are available in free
+            return icon.membership.free.includes('solid') || icon.membership.free.includes('brands');
+        }
+
+        function isBrand(icon) {
+            return icon.membership[versionType.toLowerCase()].includes('brands');
         }
 
         async function callAPI(searchString) {


### PR DESCRIPTION
This is based on #6. You can choose if you want to have to choose a version, then merge #6. If you want auto-detection, merge this.

It uses a regex to find the version in the required stylesheet. For pro or free, it searches in the font families for "pro". 

This works from version 5.6.0 to now. 