### PR TITLE
style: fix icon style buttons alignment

### DIFF
--- a/StreamAwesome/src/components/settings/GeneralOptions.vue
+++ b/StreamAwesome/src/components/settings/GeneralOptions.vue
@@ -39,7 +39,7 @@ function createFontAwesomeIconDisplay(style: FontAwesomeStyle): FontAwesomeIcon 
     const unicode = props.icon.fontAwesomeIcon.unicode
     const isBrandsIcon = props.icon.fontAwesomeIcon.isBrandsIcon
     const family = props.icon.fontAwesomeIcon.family
-
+    
     return { id, label, unicode, isBrandsIcon, family, style }
   }
 }
@@ -50,7 +50,7 @@ defineEmits(['updateStyle', 'updateFamily', 'updateSize'])
 <template>
   <div class="mt-5">
     <label for="iconSize" class="mb-[0.5] block text-sm font-medium text-gray-900 dark:text-white"
-      >Icon Size and Style:
+    >Icon Size and Style:
     </label>
     <input
       id="iconSize"
@@ -62,61 +62,57 @@ defineEmits(['updateStyle', 'updateFamily', 'updateSize'])
       class="h-2 w-full cursor-pointer appearance-none rounded-lg bg-gray-200 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:bg-gray-700"
     />
   </div>
-
-  <div class="rounded-md shadow-sm" id="familySelector">
-    <span v-for="(family, index) in relevantFamilies" :key="family">
-      <input
-        type="radio"
-        name="iconFamily"
-        :id="family"
-        :value="family"
-        class="peer hidden"
-        @change="$emit('updateFamily', family)"
-        :checked="family === props.icon?.fontAwesomeIcon.family"
-      />
-      <label
-        :for="family"
-        :class="{
-          'rounded-s-lg': index === 0,
-          'rounded-e-lg': index === relevantFamilies.length - 1
-        }"
-        class="cursor-pointer select-none border border-gray-200 bg-white px-4 py-2 text-lg text-gray-900 hover:bg-gray-100 hover:text-gray-600 focus:z-10 peer-checked:border-blue-600 peer-checked:text-blue-600 dark:border-gray-700 dark:bg-gray-800 dark:text-white dark:hover:bg-gray-700 dark:hover:text-gray-300 dark:peer-checked:text-blue-500"
-      >
-        {{ family[0].toUpperCase() + family.slice(1) }}
-      </label>
-    </span>
-  </div>
-
-  <div class="rounded-md shadow-sm" id="styleSelector">
-    <span v-for="(style, index) in relevantStyles" :key="style">
-      <input
-        type="radio"
-        name="iconStyle"
-        :id="style"
-        :value="style"
-        class="peer hidden"
-        @change="$emit('updateStyle', style)"
-        :checked="style === props.icon?.fontAwesomeIcon.style"
-      />
-      <label
-        :for="style"
-        :class="{
-          'rounded-s-lg': index === 0,
-          'rounded-e-lg': index === relevantStyles.length - 1
-        }"
-        class="cursor-pointer select-none border border-gray-200 bg-white px-4 py-2 text-2xl text-gray-900 hover:bg-gray-100 hover:text-gray-600 focus:z-10 peer-checked:border-blue-600 peer-checked:text-blue-600 dark:border-gray-700 dark:bg-gray-800 dark:text-white dark:hover:bg-gray-700 dark:hover:text-gray-300 dark:peer-checked:text-blue-500"
-      >
-        <Icon
-          :fontAwesomeIcon="createFontAwesomeIconDisplay(style)"
-          :title="style[0].toUpperCase() + style.slice(1)"
+  
+  <section>
+    <div class="flex rounded-md shadow-sm">
+      <div class="flex-1" v-for="(family, index) in relevantFamilies" :key="family">
+        <input
+          type="radio"
+          name="iconFamily"
+          :id="family"
+          :value="family"
+          class="peer hidden"
+          @change="$emit('updateFamily', family)"
+          :checked="family === props.icon?.fontAwesomeIcon.family"
         />
-      </label>
-    </span>
-  </div>
+        <label
+          :for="family"
+          :class="{
+            'rounded-s-lg': index === 0,
+            'rounded-e-lg': index === relevantFamilies.length - 1
+          }"
+          class="block cursor-pointer select-none border border-gray-200 bg-white px-4 py-2 text-lg text-gray-900 hover:bg-gray-100 hover:text-gray-600 focus:z-10 peer-checked:border-blue-600 peer-checked:text-blue-600 dark:border-gray-700 dark:bg-gray-800 dark:text-white dark:hover:bg-gray-700 dark:hover:text-gray-300 dark:peer-checked:text-blue-500"
+        >
+          {{ family[0].toUpperCase() + family.slice(1) }}
+        </label>
+      </div>
+    </div>
+    
+    <div class="flex mt-4 rounded-md shadow-sm">
+      <div class="flex-1" v-for="(style, index) in relevantStyles" :key="style">
+        <input
+          type="radio"
+          name="iconStyle"
+          :id="style"
+          :value="style"
+          class="peer hidden"
+          @change="$emit('updateStyle', style)"
+          :checked="style === props.icon?.fontAwesomeIcon.style"
+        />
+        <label
+          :for="style"
+          :class="{
+            'rounded-s-lg': index === 0,
+            'rounded-e-lg': index === relevantStyles.length - 1
+          }"
+          class="block cursor-pointer select-none border border-gray-200 bg-white px-4 py-2 text-2xl text-gray-900 hover:bg-gray-100 hover:text-gray-600 focus:z-10 peer-checked:border-blue-600 peer-checked:text-blue-600 dark:border-gray-700 dark:bg-gray-800 dark:text-white dark:hover:bg-gray-700 dark:hover:text-gray-300 dark:peer-checked:text-blue-500"
+        >
+          <Icon
+            :fontAwesomeIcon="createFontAwesomeIconDisplay(style)"
+            :title="style[0].toUpperCase() + style.slice(1)"
+          />
+        </label>
+      </div>
+    </div>
+  </section>
 </template>
-
-<style scoped>
-#styleSelector {
-  max-width: 256px;
-}
-</style>

--- a/StreamAwesome/src/components/settings/GeneralOptions.vue
+++ b/StreamAwesome/src/components/settings/GeneralOptions.vue
@@ -39,7 +39,7 @@ function createFontAwesomeIconDisplay(style: FontAwesomeStyle): FontAwesomeIcon 
     const unicode = props.icon.fontAwesomeIcon.unicode
     const isBrandsIcon = props.icon.fontAwesomeIcon.isBrandsIcon
     const family = props.icon.fontAwesomeIcon.family
-    
+
     return { id, label, unicode, isBrandsIcon, family, style }
   }
 }
@@ -50,7 +50,7 @@ defineEmits(['updateStyle', 'updateFamily', 'updateSize'])
 <template>
   <div class="mt-5">
     <label for="iconSize" class="mb-[0.5] block text-sm font-medium text-gray-900 dark:text-white"
-    >Icon Size and Style:
+      >Icon Size and Style:
     </label>
     <input
       id="iconSize"
@@ -62,7 +62,7 @@ defineEmits(['updateStyle', 'updateFamily', 'updateSize'])
       class="h-2 w-full cursor-pointer appearance-none rounded-lg bg-gray-200 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:bg-gray-700"
     />
   </div>
-  
+
   <section>
     <div class="flex rounded-md shadow-sm">
       <div class="flex-1" v-for="(family, index) in relevantFamilies" :key="family">
@@ -87,8 +87,8 @@ defineEmits(['updateStyle', 'updateFamily', 'updateSize'])
         </label>
       </div>
     </div>
-    
-    <div class="flex mt-4 rounded-md shadow-sm">
+
+    <div class="mt-4 flex rounded-md shadow-sm">
       <div class="flex-1" v-for="(style, index) in relevantStyles" :key="style">
         <input
           type="radio"

--- a/StreamAwesome/src/components/settings/GeneralOptions.vue
+++ b/StreamAwesome/src/components/settings/GeneralOptions.vue
@@ -81,7 +81,7 @@ defineEmits(['updateStyle', 'updateFamily', 'updateSize'])
             'rounded-s-lg': index === 0,
             'rounded-e-lg': index === relevantFamilies.length - 1
           }"
-          class="block cursor-pointer select-none border border-gray-200 bg-white px-4 py-2 text-lg text-gray-900 hover:bg-gray-100 hover:text-gray-600 focus:z-10 peer-checked:border-blue-600 peer-checked:text-blue-600 dark:border-gray-700 dark:bg-gray-800 dark:text-white dark:hover:bg-gray-700 dark:hover:text-gray-300 dark:peer-checked:text-blue-500"
+          class="block cursor-pointer select-none border border-gray-200 bg-white px-4 py-2 text-center text-lg text-gray-900 hover:bg-gray-100 hover:text-gray-600 focus:z-10 peer-checked:border-blue-600 peer-checked:text-blue-600 dark:border-gray-700 dark:bg-gray-800 dark:text-white dark:hover:bg-gray-700 dark:hover:text-gray-300 dark:peer-checked:text-blue-500"
         >
           {{ family[0].toUpperCase() + family.slice(1) }}
         </label>
@@ -105,7 +105,7 @@ defineEmits(['updateStyle', 'updateFamily', 'updateSize'])
             'rounded-s-lg': index === 0,
             'rounded-e-lg': index === relevantStyles.length - 1
           }"
-          class="block cursor-pointer select-none border border-gray-200 bg-white px-4 py-2 text-2xl text-gray-900 hover:bg-gray-100 hover:text-gray-600 focus:z-10 peer-checked:border-blue-600 peer-checked:text-blue-600 dark:border-gray-700 dark:bg-gray-800 dark:text-white dark:hover:bg-gray-700 dark:hover:text-gray-300 dark:peer-checked:text-blue-500"
+          class="block cursor-pointer select-none border border-gray-200 bg-white px-4 py-2 text-center text-2xl text-gray-900 hover:bg-gray-100 hover:text-gray-600 focus:z-10 peer-checked:border-blue-600 peer-checked:text-blue-600 dark:border-gray-700 dark:bg-gray-800 dark:text-white dark:hover:bg-gray-700 dark:hover:text-gray-300 dark:peer-checked:text-blue-500"
         >
           <Icon
             :fontAwesomeIcon="createFontAwesomeIconDisplay(style)"


### PR DESCRIPTION
This PR fixes the alignment of the icon style buttons.
The rest of the discussed style fixes can be implemented on top of this PR after it's merged.

**Before:**
![before1](https://github.com/sebinside/StreamAwesome/assets/69698193/84ca6bbc-7061-4744-90ec-92446fd62ff2) ![before2](https://github.com/sebinside/StreamAwesome/assets/69698193/4a31f302-0b22-4de1-b2db-8233773fb222)

**After:**

![after](https://github.com/sebinside/StreamAwesome/assets/69698193/134dc244-72b4-4699-a69e-019f9abf768d)

---

I don't have access to some FontAwesome icons. That's why some icons are broken in the screenshot.

The GitHub diff screen doesn't show the changes completely accurate. I only adjusted _a bit_ of HTML and CSS. It's not as much as it looks like.