### PR TITLE
refactor: simplify ref types

### DIFF
--- a/StreamAwesome/src/components/browser/IconBrowser.vue
+++ b/StreamAwesome/src/components/browser/IconBrowser.vue
@@ -4,12 +4,12 @@ import Icon from '@/components/utils/IconDisplay.vue'
 
 import { FontAwesomeBrowser } from '@/logic/fontAwesomeBrowser'
 import type { FontAwesomeIcon } from '@/model/fontAwesomeIcon'
-import { FontAwesomeIconType } from '@/model/fontAwesomeIconType'
+import type { FontAwesomeIconType } from '@/model/fontAwesomeIconType'
 import { fontAwesomeVersionInfo } from '@/model/versions'
 import { useIconsStore } from '@/stores/icons'
-import { ref, type Ref } from 'vue'
+import { ref } from 'vue'
 
-let availableIcons: Ref<FontAwesomeIconType[]> = ref([])
+let availableIcons = ref<FontAwesomeIconType[]>([])
 const iconStore = useIconsStore()
 
 function selectIcon(icon: FontAwesomeIconType) {

--- a/StreamAwesome/src/components/settings/presets/ColorSelector.vue
+++ b/StreamAwesome/src/components/settings/presets/ColorSelector.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { CustomIcon } from '@/model/customIcon'
 import chroma from 'chroma-js'
-import { ref, type Ref } from 'vue'
+import { ref } from 'vue'
 
 // TODO: Replace color selector with actual legacy icon template
 const DEFAULT_HUE = 217
@@ -17,11 +17,11 @@ const emit = defineEmits(['input'])
 
 const color = chroma(props.icon?.foregroundColor ?? '#000000')
 
-const currentHue: Ref<Number> = ref(color.hsl()[0])
-const currentSaturation: Ref<Number> = ref(color.hsl()[1])
-const currentLightness: Ref<Number> = ref(color.hsl()[2])
+const currentHue = ref(color.hsl()[0])
+const currentSaturation = ref(color.hsl()[1])
+const currentLightness = ref(color.hsl()[2])
 
-const settingsExpanded: Ref<boolean> = ref(false)
+const settingsExpanded = ref(false)
 
 const toggleSettings = () => {
   settingsExpanded.value = !settingsExpanded.value


### PR DESCRIPTION
Such ref types:

```js
let availableIcons: Ref<FontAwesomeIconType[]> = ref([])
```
can be simplified like this:

```js
let availableIcons = ref<FontAwesomeIconType[]>([])
```

---

If a `ref()` has an initial value, the type is inferred automagically.

```js
const currentHue: Ref<Number> = ref(color.hsl()[0])
```

`Ref<Number>` is usually omitted like this:

![image](https://github.com/sebinside/StreamAwesome/assets/69698193/08c313c7-2a32-4232-968e-5da3b5614eb9)
