### PR TITLE
refactor: implement emit types

### DIFF
--- a/StreamAwesome/src/components/IconCanvas.vue
+++ b/StreamAwesome/src/components/IconCanvas.vue
@@ -43,7 +43,9 @@ function createGenerator() {
   }
 }
 
-defineEmits(['downloadIcon'])
+defineEmits<{
+  downloadIcon: []
+}>()
 </script>
 
 <template>

--- a/StreamAwesome/src/components/browser/IconBrowser.vue
+++ b/StreamAwesome/src/components/browser/IconBrowser.vue
@@ -43,7 +43,7 @@ async function queryIcons(query: string) {
 queryIcons('video')
 </script>
 <template>
-  <InputGroup label="Search:" inputId="iconBrowser" @input="queryIcons($event.target.value)" />
+  <InputGroup label="Search:" inputId="iconBrowser" @on-input="queryIcons" />
   <div class="mt-3 grid grid-cols-3 grid-rows-3 justify-items-stretch gap-2 text-center">
     <Icon
       v-for="icon of availableIcons"

--- a/StreamAwesome/src/components/browser/InputGroup.vue
+++ b/StreamAwesome/src/components/browser/InputGroup.vue
@@ -6,13 +6,11 @@ defineProps({
   inputId: {
     required: true,
     type: String
-  },
-  modelValue: {
-    required: false,
-    default: 'question'
   }
 })
-defineEmits(['update:modelValue'])
+defineEmits<{
+  onInput: [inputValue: string]
+}>()
 </script>
 
 <template>
@@ -21,11 +19,11 @@ defineEmits(['update:modelValue'])
       >{{ label }}
     </label>
     <input
+      type="text"
+      value="question"
       tabindex="1"
       :id="inputId"
-      type="text"
-      :value="modelValue"
-      @input="$emit('update:modelValue', $event.target)"
+      @input="(event) => $emit('onInput', (event.target as HTMLInputElement).value)"
       class="block w-full rounded-lg border border-gray-300 bg-gray-50 p-2.5 text-sm text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder-gray-400"
     />
   </div>

--- a/StreamAwesome/src/components/settings/DownloadButton.vue
+++ b/StreamAwesome/src/components/settings/DownloadButton.vue
@@ -1,5 +1,7 @@
 <script setup lang="ts">
-defineEmits(['downloadIcon'])
+defineEmits<{
+  downloadIcon: []
+}>()
 </script>
 
 <template>

--- a/StreamAwesome/src/components/settings/GeneralOptions.vue
+++ b/StreamAwesome/src/components/settings/GeneralOptions.vue
@@ -4,6 +4,7 @@ import {
   BrandsKeyword,
   FontAwesomeFamilyKeys,
   FontAwesomeStyleKeys,
+  type FontAwesomeFamily,
   type FontAwesomeStyle
 } from '@/model/fontAwesomeConstants'
 import { FontAwesomeIconType } from '@/model/fontAwesomeIconType'
@@ -44,7 +45,16 @@ function createFontAwesomeIconDisplay(style: FontAwesomeStyle): FontAwesomeIcon 
   }
 }
 
-defineEmits(['updateStyle', 'updateFamily', 'updateSize'])
+const emit = defineEmits<{
+  updateSize: [size: number],
+  updateFamily: [family: FontAwesomeFamily],
+  updateStyle: [style: FontAwesomeStyle]
+}>()
+
+function updateSize(event: Event) {
+  const size = +(event.target as HTMLInputElement).value
+  emit('updateSize', size)
+}
 </script>
 
 <template>
@@ -56,7 +66,7 @@ defineEmits(['updateStyle', 'updateFamily', 'updateSize'])
       id="iconSize"
       type="range"
       :value="props.icon?.fontSize ?? 180"
-      @input="(event) => $emit('updateSize', (event.target as HTMLInputElement).value)"
+      @input="event => updateSize(event)"
       min="50"
       max="250"
       class="h-2 w-full cursor-pointer appearance-none rounded-lg bg-gray-200 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:bg-gray-700"
@@ -72,7 +82,7 @@ defineEmits(['updateStyle', 'updateFamily', 'updateSize'])
           :id="family"
           :value="family"
           class="peer hidden"
-          @change="$emit('updateFamily', family)"
+          @input="$emit('updateFamily', family)"
           :checked="family === props.icon?.fontAwesomeIcon.family"
         />
         <label
@@ -96,7 +106,7 @@ defineEmits(['updateStyle', 'updateFamily', 'updateSize'])
           :id="style"
           :value="style"
           class="peer hidden"
-          @change="$emit('updateStyle', style)"
+          @input="$emit('updateStyle', style)"
           :checked="style === props.icon?.fontAwesomeIcon.style"
         />
         <label

--- a/StreamAwesome/src/components/settings/GeneralOptions.vue
+++ b/StreamAwesome/src/components/settings/GeneralOptions.vue
@@ -46,8 +46,8 @@ function createFontAwesomeIconDisplay(style: FontAwesomeStyle): FontAwesomeIcon 
 }
 
 const emit = defineEmits<{
-  updateSize: [size: number],
-  updateFamily: [family: FontAwesomeFamily],
+  updateSize: [size: number]
+  updateFamily: [family: FontAwesomeFamily]
   updateStyle: [style: FontAwesomeStyle]
 }>()
 
@@ -66,7 +66,7 @@ function updateSize(event: Event) {
       id="iconSize"
       type="range"
       :value="props.icon?.fontSize ?? 180"
-      @input="event => updateSize(event)"
+      @input="(event) => updateSize(event)"
       min="50"
       max="250"
       class="h-2 w-full cursor-pointer appearance-none rounded-lg bg-gray-200 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:bg-gray-700"

--- a/StreamAwesome/src/components/settings/IconSettings.vue
+++ b/StreamAwesome/src/components/settings/IconSettings.vue
@@ -26,7 +26,9 @@ function updateStyle(style: FontAwesomeStyle) {
   currentIcon.fontAwesomeIcon.style = style
 }
 
-defineEmits(['downloadIcon'])
+defineEmits<{
+  downloadIcon: []
+}>()
 </script>
 
 <template>

--- a/StreamAwesome/src/components/settings/IconSettings.vue
+++ b/StreamAwesome/src/components/settings/IconSettings.vue
@@ -3,7 +3,7 @@ import type { CustomIcon } from '@/model/customIcon'
 import PresetOptions from '@/components/settings/PresetOptions.vue'
 import GeneralOptions from '@/components/settings/GeneralOptions.vue'
 import DownloadButton from '@/components/settings/DownloadButton.vue'
-import { type FontAwesomeFamily, type FontAwesomeStyle } from '@/model/fontAwesomeConstants'
+import type { FontAwesomeFamily, FontAwesomeStyle } from '@/model/fontAwesomeConstants'
 import { reactive } from 'vue'
 const props = defineProps({
   icon: {
@@ -14,16 +14,16 @@ const props = defineProps({
 const currentIcon = reactive(props.icon ?? ({} as CustomIcon))
 
 // TODO: More refactoring required
-function updateStyle(style: FontAwesomeStyle) {
-  currentIcon.fontAwesomeIcon.style = style
+function updateSize(size: number) {
+  currentIcon.fontSize = size
 }
 
 function updateFamily(family: FontAwesomeFamily) {
   currentIcon.fontAwesomeIcon.family = family
 }
 
-function updateSize(size: number) {
-  currentIcon.fontSize = size
+function updateStyle(style: FontAwesomeStyle) {
+  currentIcon.fontAwesomeIcon.style = style
 }
 
 defineEmits(['downloadIcon'])
@@ -34,9 +34,9 @@ defineEmits(['downloadIcon'])
 
   <GeneralOptions
     :icon="icon"
-    @updateStyle="updateStyle"
-    @updateFamily="updateFamily"
     @updateSize="updateSize"
+    @updateFamily="updateFamily"
+    @updateStyle="updateStyle"
   />
 
   <DownloadButton @downloadIcon="$emit('downloadIcon')" />

--- a/StreamAwesome/src/components/settings/PresetOptions.vue
+++ b/StreamAwesome/src/components/settings/PresetOptions.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { CustomIcon } from '@/model/customIcon'
+import type { CustomIcon, ColorValue } from '@/model/customIcon'
 import ColorSelector from '@/components/settings/presets/ColorSelector.vue'
 import chroma from 'chroma-js'
 import { reactive } from 'vue'
@@ -12,7 +12,7 @@ const props = defineProps({
 // TODO: Add patterns selector and switch in the template
 const currentIcon = reactive(props.icon ?? ({} as CustomIcon))
 
-function updateColorValue(param: { key: 'h' | 's' | 'l'; value: number }) {
+function updateColorValue(param: ColorValue) {
   if (!param.value) return
 
   const foregroundColor = chroma(currentIcon.foregroundColor)

--- a/StreamAwesome/src/components/settings/presets/ColorSelector.vue
+++ b/StreamAwesome/src/components/settings/presets/ColorSelector.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { CustomIcon } from '@/model/customIcon'
+import type { CustomIcon, ColorValue } from '@/model/customIcon'
 import chroma from 'chroma-js'
 import { ref } from 'vue'
 
@@ -13,7 +13,6 @@ const props = defineProps({
     type: Object as () => CustomIcon
   }
 })
-const emit = defineEmits(['input'])
 
 const color = chroma(props.icon?.foregroundColor ?? '#000000')
 
@@ -27,10 +26,15 @@ const toggleSettings = () => {
   settingsExpanded.value = !settingsExpanded.value
 }
 
+const emit = defineEmits<{
+  input: [colorValue: ColorValue]
+}>()
+
 const resetColor = () => {
   currentHue.value = DEFAULT_HUE
   currentSaturation.value = DEFAULT_SATURATION
   currentLightness.value = DEFAULT_LIGHTNESS
+
   emit('input', { key: 'h', value: DEFAULT_HUE })
   emit('input', { key: 's', value: DEFAULT_SATURATION })
   emit('input', { key: 'l', value: DEFAULT_LIGHTNESS })

--- a/StreamAwesome/src/model/customIcon.ts
+++ b/StreamAwesome/src/model/customIcon.ts
@@ -6,3 +6,7 @@ export interface CustomIcon {
   fontSize: number
   fontAwesomeIcon: FontAwesomeIcon
 }
+export interface ColorValue {
+  key: 'h' | 's' | 'l'
+  value: number
+}


### PR DESCRIPTION
Currently, emits are listed by using the _runtime declaration_ without types:

```ts
defineEmits(['updateStyle', 'updateFamily', 'updateSize'])
```

This PR implements emit types by using the _type-based declaration_:

```ts
const emit = defineEmits<{
  updateSize: [size: number]
  updateFamily: [family: FontAwesomeFamily]
  updateStyle: [style: FontAwesomeStyle]
}>()
```

---

The _type-based declaration_ provides type-safety and autocompletion when using emits which is super awesome.

Currently, it's possible to emit _any_ value.
With this PR, only the specified values are allowed and such errors will be caught:

![image](https://github.com/sebinside/StreamAwesome/assets/69698193/9381e434-ba0b-4fa4-9c88-c17d64c9888a)

---

Here is an example from the documentation:

![image](https://github.com/sebinside/StreamAwesome/assets/69698193/542ee73a-f120-4363-88d6-199fb452675d)

https://vuejs.org/api/sfc-script-setup.html#type-only-props-emit-declarations