### PR TITLE
refactor: implement prop types

### DIFF
--- a/StreamAwesome/src/components/IconCanvas.vue
+++ b/StreamAwesome/src/components/IconCanvas.vue
@@ -6,11 +6,9 @@ import { useFontsStatusStore } from '@/stores/fontStatus'
 
 const fontStatusStore = useFontsStatusStore()
 const iconCanvas = ref<HTMLCanvasElement | null>(null)
-const props = defineProps({
-  icon: {
-    type: Object as () => CustomIcon
-  }
-})
+const props = defineProps<{
+  icon: CustomIcon
+}>()
 
 onMounted(() => {
   waitForRequiredInitialization(createGenerator)

--- a/StreamAwesome/src/components/browser/InputGroup.vue
+++ b/StreamAwesome/src/components/browser/InputGroup.vue
@@ -1,13 +1,8 @@
 <script setup lang="ts">
-defineProps({
-  label: {
-    type: String
-  },
-  inputId: {
-    required: true,
-    type: String
-  }
-})
+defineProps<{
+  label: string
+  inputId: string
+}>()
 defineEmits<{
   onInput: [inputValue: string]
 }>()

--- a/StreamAwesome/src/components/settings/GeneralOptions.vue
+++ b/StreamAwesome/src/components/settings/GeneralOptions.vue
@@ -13,11 +13,9 @@ import type { FontAwesomeIcon } from '@/model/fontAwesomeIcon'
 import { fontAwesomeVersionInfo } from '@/model/versions'
 import { reactive } from 'vue'
 
-const props = defineProps({
-  icon: {
-    type: Object as () => CustomIcon
-  }
-})
+const props = defineProps<{
+  icon: CustomIcon
+}>()
 
 const currentIcon = reactive(props.icon ?? ({} as CustomIcon))
 

--- a/StreamAwesome/src/components/settings/IconSettings.vue
+++ b/StreamAwesome/src/components/settings/IconSettings.vue
@@ -3,12 +3,10 @@ import type { CustomIcon } from '@/model/customIcon'
 import PresetOptions from '@/components/settings/PresetOptions.vue'
 import GeneralOptions from '@/components/settings/GeneralOptions.vue'
 import DownloadButton from '@/components/settings/DownloadButton.vue'
-defineProps({
-  icon: {
-    type: Object as () => CustomIcon
-  }
-})
 
+defineProps<{
+  icon: CustomIcon
+}>()
 defineEmits<{
   downloadIcon: []
 }>()

--- a/StreamAwesome/src/components/settings/PresetOptions.vue
+++ b/StreamAwesome/src/components/settings/PresetOptions.vue
@@ -2,11 +2,10 @@
 import type { CustomIcon } from '@/model/customIcon'
 import ElgatoClassic from '@/components/settings/presets/ElgatoClassic.vue'
 import { ref } from 'vue'
-defineProps({
-  icon: {
-    type: Object as () => CustomIcon
-  }
-})
+
+defineProps<{
+  icon: CustomIcon
+}>()
 
 // TODO: Move somewhere else in the refactoring of the model
 const availablePresets = ['Elgato Classic', 'Other']

--- a/StreamAwesome/src/components/settings/presets/ElgatoClassic.vue
+++ b/StreamAwesome/src/components/settings/presets/ElgatoClassic.vue
@@ -3,11 +3,9 @@ import { reactive, ref } from 'vue'
 import chroma from 'chroma-js'
 import type { CustomIcon, ColorValue } from '@/model/customIcon'
 
-const props = defineProps({
-  icon: {
-    type: Object as () => CustomIcon
-  }
-})
+const props = defineProps<{
+  icon: CustomIcon
+}>()
 
 const currentIcon = reactive(props.icon ?? ({} as CustomIcon))
 const color = chroma(props.icon?.foregroundColor ?? '#000000')

--- a/StreamAwesome/src/components/utils/IconDisplay.vue
+++ b/StreamAwesome/src/components/utils/IconDisplay.vue
@@ -2,12 +2,9 @@
 import type { FontAwesomeIcon } from '@/model/fontAwesomeIcon'
 import { FontAwesomeIconType } from '@/model/fontAwesomeIconType'
 
-const props = defineProps({
-  fontAwesomeIcon: {
-    required: true,
-    type: Object as () => FontAwesomeIcon
-  }
-})
+const props = defineProps<{
+  fontAwesomeIcon: FontAwesomeIcon
+}>()
 </script>
 
 <template>


### PR DESCRIPTION
Implement prop types by using the _type-based declaration_.

Convert the _runtime declaration_:

```ts
defineProps({
  icon: {
    type: Object as () => CustomIcon
  }
})
```

to the _type-based declaration_:

```ts
defineProps<{
  icon: CustomIcon
}>()
```

The _type-based declaration_ provides type-safety and autocompletion when using props.
The prop types work exactly like the emit types (#199).