### PR TITLE
refactor: Preset definition

### DIFF
--- a/StreamAwesome/src/components/settings/PresetOptions.vue
+++ b/StreamAwesome/src/components/settings/PresetOptions.vue
@@ -1,33 +1,43 @@
 <script setup lang="ts">
 import type { CustomIcon } from '@/model/customIcon'
 import ElgatoClassic from '@/components/settings/presets/ElgatoClassic.vue'
-import { ref } from 'vue'
+import OtherComponent from '@/components/settings/presets/OtherComponent.vue'
+import { ref, computed } from 'vue'
+import type { VNode, Component } from 'vue'
 
 defineProps<{
   icon: CustomIcon
 }>()
 
 // TODO: Move somewhere else in the refactoring of the model
-const availablePresets = ['Elgato Classic', 'Other']
-type IconPreset = (typeof availablePresets)[number]
+const presets = {
+  'Elgato Classic': ElgatoClassic,
+  Other: OtherComponent
+} satisfies Record<string, VNode | Component>
+const presetKeys = Object.keys(presets) as IconPreset[]
+type IconPreset = keyof typeof presets
 
 const selectedPreset = ref<IconPreset>('Elgato Classic')
+const selectedPresetComponent = computed(() => {
+  return presets[selectedPreset.value]
+})
 </script>
 
 <template>
-  <label for="presetselector" class="mb-2 block text-sm font-medium text-gray-900 dark:text-white"
-    >Select Icon Preset:</label
-  >
-  <select
-    id="presetselector"
-    v-model="selectedPreset"
-    class="mb-6 block w-full rounded-lg border border-gray-300 bg-gray-50 p-2.5 text-sm text-gray-900 focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder-gray-400 dark:focus:border-blue-500 dark:focus:ring-blue-500"
-  >
-    <option v-for="preset in availablePresets" :value="preset" :key="preset">
-      {{ preset }}
-    </option>
-  </select>
+  <div>
+    <label for="presetselector" class="mb-2 block text-sm font-medium text-gray-900 dark:text-white"
+      >Select Icon Preset:</label
+    >
+    <select
+      id="presetselector"
+      v-model="selectedPreset"
+      class="mb-6 block w-full rounded-lg border border-gray-300 bg-gray-50 p-2.5 text-sm text-gray-900 focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder-gray-400 dark:focus:border-blue-500 dark:focus:ring-blue-500"
+    >
+      <option v-for="preset in presetKeys" :value="preset" :key="preset">
+        {{ preset }}
+      </option>
+    </select>
 
-  <ElgatoClassic :icon="icon" v-if="selectedPreset === 'Elgato Classic'" />
-  <div v-if="selectedPreset === 'Other'">No other presets available yet</div>
+    <component :is="selectedPresetComponent" :icon="icon" />
+  </div>
 </template>

--- a/StreamAwesome/src/components/settings/presets/OtherComponent.vue
+++ b/StreamAwesome/src/components/settings/presets/OtherComponent.vue
@@ -1,0 +1,15 @@
+<script setup lang="ts">
+// Temporary Preset till more are implemented
+
+import type { CustomIcon } from '@/model/customIcon'
+
+// disable for demo purposes
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const props = defineProps<{
+  icon: CustomIcon
+}>()
+</script>
+
+<template>
+  <div class="text-sm">Currently nothing else available.</div>
+</template>


### PR DESCRIPTION
* wrap component in div to apply to vue/no-multiple-template-root convention
* Presets are not depending on v-if structure anymore
* move temporary fallback into own file