### PR TITLE
#207 dynamic imports for font awesome pro css sheets

### DIFF
--- a/StreamAwesome/src/main.ts
+++ b/StreamAwesome/src/main.ts
@@ -1,21 +1,46 @@
 import './style.css'
-import '../fonts/fontawesome/css/all.min.css'
-import '../fonts/fontawesome/css/sharp-light.min.css'
-import '../fonts/fontawesome/css/sharp-thin.min.css'
-import '../fonts/fontawesome/css/sharp-regular.min.css'
-import '../fonts/fontawesome/css/sharp-solid.min.css'
-import '../fonts/fontawesome/css/regular.min.css'
-import '../fonts/fontawesome/css/solid.min.css'
-import '../fonts/fontawesome/css/brands.min.css'
+
+import { fontAwesomeVersionInfo, setFontAwesomeLicense } from '@/model/versions'
 import { createApp } from 'vue'
 import { createPinia } from 'pinia'
 
 import App from '@/App.vue'
 import router from '@/router'
 
-const app = createApp(App)
+(async () => {
+    try {
+        await loadFontAwesomeStyles()
+    } catch (error) {
+        console.error('Failed to load one or more styles, this is most likely because you are using the free version of Font Awesome. This can be avoided by changing the font license from `Free` to `Pro` in `versions.ts`:', error)
+        console.info('Changing font license to `Free`.')
+        setFontAwesomeLicense('Free')
+    }
 
-app.use(createPinia())
-app.use(router)
+    const app = createApp(App)
 
-app.mount('#app')
+    app.use(createPinia())
+    app.use(router)
+
+    app.mount('#app')
+})()
+
+async function loadFontAwesomeStyles() {
+    import('../fonts/fontawesome/css/all.min.css')
+    import('../fonts/fontawesome/css/regular.min.css')
+    import('../fonts/fontawesome/css/solid.min.css')
+    import('../fonts/fontawesome/css/brands.min.css')
+
+    if (fontAwesomeVersionInfo.fontLicense === 'Pro') {
+        // Needs to be in an array to avoid static analysis
+        const proStyles = [
+            '../fonts/fontawesome/css/sharp-light.min.css',
+            '../fonts/fontawesome/css/sharp-thin.min.css',
+            '../fonts/fontawesome/css/sharp-regular.min.css',
+            '../fonts/fontawesome/css/sharp-solid.min.css',
+        ]
+
+        for (const style of proStyles) {
+            await new Function(`return import("${style}")`)()
+        }
+    }
+}

--- a/StreamAwesome/src/model/versions.ts
+++ b/StreamAwesome/src/model/versions.ts
@@ -1,11 +1,17 @@
 export const streamAwesomeVersionInfo = '2.0.0'
 
+export type fontLicense = 'Free' | 'Pro'
+
 export const fontAwesomeVersionInfo: {
   readonly fontFamilyBase: string
   readonly fontVersion: string
-  readonly fontLicense: 'Free' | 'Pro'
+  fontLicense: fontLicense
 } = {
   fontFamilyBase: 'Font Awesome 6',
   fontVersion: '6.5.2',
   fontLicense: 'Pro'
+}
+
+export function setFontAwesomeLicense(fontLicense: fontLicense) {
+  fontAwesomeVersionInfo.fontLicense = fontLicense
 }


### PR DESCRIPTION
this solution tries to import the pro .css sheets and on error changes to license to Free. 
Needs to be tested with the pro version as well, but should work fine.

There are still some visual bugs when using the free version like this:
![image](https://github.com/sebinside/StreamAwesome/assets/31077445/7829494f-35fb-4498-a25f-e493b937583a)
