### PR TITLE
Add "View on GitHub" button

### DIFF
--- a/StreamAwesome/src/components/utils/ViewOnGithub.vue
+++ b/StreamAwesome/src/components/utils/ViewOnGithub.vue
@@ -1,0 +1,38 @@
+<template>
+  <a
+    href="https://github.com/sebinside/StreamAwesome"
+    target="_blank"
+    class="btn btn-primary float-right text-sm"
+  >
+    <button
+      class="github-button me-2 w-full rounded-lg bg-gradient-to-r from-cyan-500 to-blue-500 px-5 py-2.5 text-center text-sm font-medium text-white hover:bg-gradient-to-bl focus:outline-none focus:ring-2 focus:ring-cyan-300 dark:focus:ring-cyan-800"
+    >
+      <i class="fa-brands fa-github"></i><span class="github-text"></span>
+    </button>
+  </a>
+</template>
+
+<style scoped>
+.github-text::after {
+  content: 'View on GitHub';
+}
+
+.github-button:hover .github-text::after {
+  content: 'Vue on GitHub';
+}
+
+.github-button {
+  width: 12em;
+  height: 2.5em;
+  margin: 0;
+  line-height: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.fa-github {
+  font-size: 1.5em;
+  margin-right: 0.3em;
+}
+</style>

--- a/StreamAwesome/src/components/utils/ViewOnGithub.vue
+++ b/StreamAwesome/src/components/utils/ViewOnGithub.vue
@@ -22,8 +22,8 @@
 }
 
 .github-button {
-  width: 12em;
-  height: 2.5em;
+  width: 12rem;
+  height: 2.5rem;
   margin: 0;
   line-height: 1;
   display: flex;
@@ -32,7 +32,7 @@
 }
 
 .fa-github {
-  font-size: 1.5em;
-  margin-right: 0.3em;
+  font-size: 1.7rem;
+  margin-right: 0.5rem;
 }
 </style>

--- a/StreamAwesome/src/views/HomeView.vue
+++ b/StreamAwesome/src/views/HomeView.vue
@@ -1,14 +1,16 @@
 <script setup lang="ts">
 import MainSettings from '@/components/MainSettings.vue'
 import { streamAwesomeVersionInfo } from '@/model/versions'
+import ViewOnGithub from '@/components/utils/ViewOnGithub.vue'
 </script>
 
 <template>
-  <main>
+  <main class="relative">
     <h1 class="text-center text-3xl font-bold md:text-start">
       Stream Awesome
       <span class="text-sm text-gray-400">{{ streamAwesomeVersionInfo }}</span>
     </h1>
+    <ViewOnGithub class="absolute right-0 top-0" />
     <MainSettings />
   </main>
 </template>


### PR DESCRIPTION
Adds a small button for "View on GitHub".
![grafik](https://github.com/user-attachments/assets/7441bc59-d6de-4152-9341-1170adb6a410)

At the moment, it has some special effects when hovered but if you want me to remove that, it's fine. We don't need insiders in projects.

Closes #250 