### PR TITLE
Add bottom margin for a consistent design

### DIFF
--- a/StreamAwesome/src/App.vue
+++ b/StreamAwesome/src/App.vue
@@ -5,7 +5,7 @@ import FontLoader from '@/components/utils/FontLoader.vue'
 
 <template>
   <FontLoader />
-  <main class="m-auto mt-0 max-w-4xl bg-gray-800 p-4 text-white md:mt-10 md:rounded-2xl">
+  <main class="m-auto mt-0 max-w-4xl bg-gray-800 p-4 text-white md:mt-10 md:mb-14 md:rounded-2xl">
     <RouterView />
   </main>
 </template>

--- a/StreamAwesome/src/App.vue
+++ b/StreamAwesome/src/App.vue
@@ -5,7 +5,7 @@ import FontLoader from '@/components/utils/FontLoader.vue'
 
 <template>
   <FontLoader />
-  <main class="m-auto mt-0 max-w-4xl bg-gray-800 p-4 text-white md:mt-10 md:mb-14 md:rounded-2xl">
+  <main class="m-auto mt-0 max-w-4xl bg-gray-800 p-4 text-white md:my-14 md:rounded-2xl">
     <RouterView />
   </main>
 </template>

--- a/StreamAwesome/src/components/utils/FontLoader.vue
+++ b/StreamAwesome/src/components/utils/FontLoader.vue
@@ -5,17 +5,19 @@ document.fonts.onloadingdone = () => fontStatusStore.setFontsLoaded()
 </script>
 
 <template>
-  <i class="fa-solid fa-glasses"></i>
-  <i class="fa-regular fa-glasses"></i>
-  <i class="fa-light fa-glasses"></i>
-  <i class="fa-duotone fa-glasses"></i>
-  <i class="fa-thin fa-glasses"></i>
-  <i class="fa-sharp fa-solid fa-glasses"></i>
-  <i class="fa-sharp fa-regular fa-glasses"></i>
-  <i class="fa-sharp fa-light fa-glasses"></i>
-  <i class="fa-sharp fa-thin fa-glasses"></i>
-  <i class="fa-sharp fa-duotone fa-glasses"></i>
-  <i class="fa-brands fa-font-awesome"></i>
+  <div class="absolute">
+    <i class="fa-solid fa-glasses"></i>
+    <i class="fa-regular fa-glasses"></i>
+    <i class="fa-light fa-glasses"></i>
+    <i class="fa-duotone fa-glasses"></i>
+    <i class="fa-thin fa-glasses"></i>
+    <i class="fa-sharp fa-solid fa-glasses"></i>
+    <i class="fa-sharp fa-regular fa-glasses"></i>
+    <i class="fa-sharp fa-light fa-glasses"></i>
+    <i class="fa-sharp fa-thin fa-glasses"></i>
+    <i class="fa-sharp fa-duotone fa-glasses"></i>
+    <i class="fa-brands fa-font-awesome"></i>
+  </div>
 </template>
 
 <style scoped>


### PR DESCRIPTION
This pull request adds a bottom margin of 3.5rem. This mirrors the top margin of 2.5rem + the height of 1rem used for the invisible `FontLoader`. This improves the design on less height screens.

We could consider adding a similar margin for the x-axis by adding `md:mx-10` for example to the classes as well. Since this tool is mainly used on browsers on a computer, this may be irrelevant. 