### PR TITLE
Fix tool not being usable with a free version only

### DIFF
--- a/StreamAwesome/src/main.ts
+++ b/StreamAwesome/src/main.ts
@@ -33,10 +33,14 @@ async function loadFontAwesomeStyles() {
   import('../fonts/fontawesome/css/brands.min.css')
 
   if (fontAwesomeVersionInfo.fontLicense === 'Pro') {
-    import('../fonts/fontawesome/css/sharp-light.min.css')
-    import('../fonts/fontawesome/css/sharp-thin.min.css')
-    import('../fonts/fontawesome/css/sharp-regular.min.css')
-    import('../fonts/fontawesome/css/sharp-solid.min.css')
-    import('../fonts/fontawesome/css/sharp-duotone-solid.min.css')
+    const proStyles = [
+      '../fonts/fontawesome/css/sharp-light.min.css',
+      '../fonts/fontawesome/css/sharp-thin.min.css',
+      '../fonts/fontawesome/css/sharp-regular.min.css',
+      '../fonts/fontawesome/css/sharp-solid.min.css',
+      '../fonts/fontawesome/css/sharp-duotone-solid.min.css'
+    ];
+
+    await Promise.all(proStyles.map(style => import(style)));
   }
 }

--- a/StreamAwesome/src/main.ts
+++ b/StreamAwesome/src/main.ts
@@ -7,16 +7,7 @@ import { createPinia } from 'pinia'
 import App from '@/App.vue'
 import router from '@/router'
 ;(async () => {
-  try {
-    await loadFontAwesomeStyles()
-  } catch (error) {
-    console.error(
-      'Failed to load one or more styles, this is most likely because you are using the free version of Font Awesome. This can be avoided by changing the font license from `Free` to `Pro` in `versions.ts`:',
-      error
-    )
-    console.info('Changing font license to `Free`.')
-    setFontAwesomeLicense('Free')
-  }
+  await loadFontAwesomeStyles()
 
   const app = createApp(App)
 
@@ -27,20 +18,30 @@ import router from '@/router'
 })()
 
 async function loadFontAwesomeStyles() {
-  import('../fonts/fontawesome/css/all.min.css')
-  import('../fonts/fontawesome/css/regular.min.css')
-  import('../fonts/fontawesome/css/solid.min.css')
-  import('../fonts/fontawesome/css/brands.min.css')
+  const freeStyles = import.meta.glob([
+    '../fonts/fontawesome/css/all.min.css',
+    '../fonts/fontawesome/css/regular.min.css',
+    '../fonts/fontawesome/css/solid.min.css',
+    '../fonts/fontawesome/css/brands.min.css'
+  ])
+
+  await Promise.all(Object.values(freeStyles).map(importModule => importModule()))
 
   if (fontAwesomeVersionInfo.fontLicense === 'Pro') {
-    const proStyles = [
+    const proStyles = import.meta.glob([
       '../fonts/fontawesome/css/sharp-light.min.css',
       '../fonts/fontawesome/css/sharp-thin.min.css',
       '../fonts/fontawesome/css/sharp-regular.min.css',
       '../fonts/fontawesome/css/sharp-solid.min.css',
       '../fonts/fontawesome/css/sharp-duotone-solid.min.css'
-    ];
+    ])
 
-    await Promise.all(proStyles.map(style => import(style)));
+    if (Object.keys(proStyles).length > 0) {
+      await Promise.all(Object.values(proStyles).map(importModule => importModule()))
+    } else {
+      console.error('Failed to load one or more styles, this is most likely because you are using the free version of Font Awesome. This can be avoided by changing the font license from `Free` to `Pro` in `versions.ts`')
+      console.info('Changing font license to `Free`.')
+      setFontAwesomeLicense('Free')
+    }
   }
 }


### PR DESCRIPTION
Without this change, using the Free version of Font Awesome looked like this when starting:

![image](https://github.com/user-attachments/assets/30fa8a5a-e4ef-4105-b5a2-6e7dad8240fa)

Now, it loads fine. The only issues are in the font family and font style selection:
![image](https://github.com/user-attachments/assets/29c1324d-8f59-4459-8ea3-6ee8df561f3e)

This is only visual and doesn't impact the contribution with free version only. You are still able to run the tool without fixing this. If anyone decides to use the Free version to host this tool, this person should fix it in their fork themselves. 

Closes #248 