### PR TITLE
Add support for Safari

### DIFF
--- a/StreamAwesome/src/components/utils/FontLoader.vue
+++ b/StreamAwesome/src/components/utils/FontLoader.vue
@@ -1,7 +1,12 @@
 <script setup lang="ts">
 import { useFontsStatusStore } from '@/stores/fontStatus'
+import { onMounted } from 'vue'
+
 const fontStatusStore = useFontsStatusStore()
-document.fonts.onloadingdone = () => fontStatusStore.setFontsLoaded()
+
+onMounted(async () => {
+    fontStatusStore.setFontsLoaded()
+})
 </script>
 
 <template>


### PR DESCRIPTION
This small change changes when exactly the fonts are being loaded. I tested in a normal browser and on Safari on iOS 18.4.1, both worked just fine. Here a screenshot from iOS:

![clipboard_2025-04-17_19-45](https://github.com/user-attachments/assets/389e2af9-0f8f-4a0b-a0cd-7f91e3cf1286)

Closes #132 