### PR TITLE
Add title attribute to labels instead of icons

### DIFF
--- a/StreamAwesome/src/components/settings/GeneralOptions.vue
+++ b/StreamAwesome/src/components/settings/GeneralOptions.vue
@@ -113,6 +113,7 @@ function updateStyle(style: FontAwesomeStyle) {
         />
         <label
           :for="family"
+          :title="family[0].toUpperCase() + family.slice(1)"
           :class="{
             'rounded-s-lg': index === 0,
             'rounded-e-lg': index === relevantFamilies.length - 1
@@ -121,7 +122,6 @@ function updateStyle(style: FontAwesomeStyle) {
         >
           <Icon
             :fontAwesomeIcon="createFontAwesomeIconDisplayFromFamily(family)"
-            :title="family[0].toUpperCase() + family.slice(1)"
           />
         </label>
       </div>
@@ -144,6 +144,7 @@ function updateStyle(style: FontAwesomeStyle) {
           />
           <label
             :for="style"
+            :title="style[0].toUpperCase() + style.slice(1)"
             :class="{
               'rounded-s-lg': index === 0,
               'rounded-e-lg': index === relevantStyles.length - 1
@@ -152,7 +153,6 @@ function updateStyle(style: FontAwesomeStyle) {
           >
             <Icon
               :fontAwesomeIcon="createFontAwesomeIconDisplayFromStyle(style)"
-              :title="style[0].toUpperCase() + style.slice(1)"
             />
           </label>
         </div>


### PR DESCRIPTION
Moved the `title` attribute logic from icons to labels for better accessibility and clearer tooltips. This ensures that the Font Family and Font Style tooltip is rendered when hovering over the button, instead only on the icon itself.