### PR TITLE
Fix the build pipeline to use free version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Clone Font Awesome Overwrites ✌️
-        if: github.actor == 'sebinside' || github.actor == 'dependabot[bot]'
+        if: ${{ secrets.TOKEN }}
         uses: actions/checkout@v3
         with:
           repository: sebinside/StreamAwesome-Overwrites
@@ -26,7 +26,7 @@ jobs:
           token: ${{ secrets.TOKEN }}
 
       - name: Download FontAwesome 📦
-        if: github.actor != 'sebinside' && github.actor != 'dependabot[bot]'
+        if: ${{ !secrets.TOKEN }}
         run: |
           mkdir -p StreamAwesome/fonts/fontawesome
           wget https://use.fontawesome.com/releases/v${{ env.FONTAWESOME_VERSION }}/fontawesome-free-${{ env.FONTAWESOME_VERSION }}-web.zip -O fontawesome.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,22 +5,35 @@ on:
  push:
  pull_request:
   types: [opened, synchronize, reopened]
-      
+
+env:
+  FONTAWESOME_VERSION: "6.6.0"
+
 jobs:
   build:
-    if: github.actor == 'sebinside' || github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️
         uses: actions/checkout@v3
 
       - name: Clone Font Awesome Overwrites ✌️
+        if: github.actor == 'sebinside' || github.actor == 'dependabot[bot]'
         uses: actions/checkout@v3
         with:
           repository: sebinside/StreamAwesome-Overwrites
           path: StreamAwesome/fonts
           ref: 'main'
           token: ${{ secrets.TOKEN }}
+
+      - name: Download FontAwesome 📦
+        if: github.actor != 'sebinside' && github.actor != 'dependabot[bot]'
+        run: |
+          mkdir -p StreamAwesome/fonts/fontawesome
+          wget https://use.fontawesome.com/releases/v${{ env.FONTAWESOME_VERSION }}/fontawesome-free-${{ env.FONTAWESOME_VERSION }}-web.zip -O fontawesome.zip
+          unzip fontawesome.zip
+          cp -r fontawesome-free-${{ env.FONTAWESOME_VERSION }}-web/css StreamAwesome/fonts/fontawesome/
+          cp -r fontawesome-free-${{ env.FONTAWESOME_VERSION }}-web/webfonts StreamAwesome/fonts/fontawesome/
+          rm -rf fontawesome.zip fontawesome-free-${{ env.FONTAWESOME_VERSION }}-web
       
       - uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
This pull request relies on #287 to work correctly.

With these changes, your private repo will only be used if `sebinside` or `dependabot[bot]` are the actor, as previously done to trigger the workflow. If it's not, it will download the free version and copy the required folders to the correct location.
A workflow where it was used can be found here: https://github.com/MelanX/StreamAwesome/actions/runs/14523474672/job/40749605372
The commits don't exist anymore because I squashed and force-pushed to keep the commits here small. 

Version 6.6.0 was used because it's set in `StreamAwesome/src/model/versions.ts`. 

Closes #263 