### PR TITLE
feat: dark reader support

### DIFF
--- a/StreamAwesome/index.html
+++ b/StreamAwesome/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8">
     <link rel="icon" href="/favicon.ico">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="darkreader-lock">
     <title>Stream Awesome - Stream Deck Icon Generator using Font Awesome</title>
   </head>
   <body class="bg-gray-900">


### PR DESCRIPTION
Disabling dark reader given the website is already dark-mode only.
Per the docs: https://github.com/darkreader/darkreader/blob/main/CONTRIBUTING.md#disabling-dark-reader-on-your-site