### PR TITLE
Remove FA pro from standard build action.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,22 +16,7 @@ jobs:
       - name: Checkout 🛎️
         uses: actions/checkout@v4
 
-      - name: Clone Font Awesome Overwrites ✌️
-        env: 
-          repoToken: ${{ secrets.TOKEN }}
-        if: ${{ env.repoToken != '' }}
-        uses: actions/checkout@v4
-        with:
-          repository: sebinside/StreamAwesome-Overwrites
-          persist-credentials: false
-          path: StreamAwesome/fonts
-          ref: 'main'
-          token: ${{ secrets.TOKEN }}
-
       - name: Download FontAwesome 📦
-        env: 
-          repoToken: ${{ secrets.TOKEN }}
-        if: ${{ env.repoToken == '' }}
         run: |
           mkdir -p StreamAwesome/fonts/fontawesome
           wget https://use.fontawesome.com/releases/v${{ env.FONTAWESOME_VERSION }}/fontawesome-free-${{ env.FONTAWESOME_VERSION }}-web.zip -O fontawesome.zip


### PR DESCRIPTION
This PR removes the auth-required cloning of the FA pro repository after continued fuckup of the github checkout action, thereby hopefully resolving this problem once and for all.