### PR TITLE
Add basic support for user-defined presets storing in localStorage

### DIFF
--- a/StreamAwesome/package-lock.json
+++ b/StreamAwesome/package-lock.json
@@ -15,6 +15,7 @@
         "vue-router": "^4.4.0"
       },
       "devDependencies": {
+        "@vueuse/core": "^13.6.0",
         "@rushstack/eslint-patch": "^1.10.4",
         "@tsconfig/node18": "^18.2.4",
         "@types/chroma-js": "^3.1.1",
@@ -1254,6 +1255,12 @@
       "integrity": "sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw==",
       "dev": true
     },
+    "node_modules/@types/web-bluetooth": {
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.21.tgz",
+      "integrity": "sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==",
+      "license": "MIT"
+    },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "7.6.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-7.6.0.tgz",
@@ -1865,6 +1872,44 @@
         "vue": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@vueuse/core": {
+      "version": "13.6.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-13.6.0.tgz",
+      "integrity": "sha512-DJbD5fV86muVmBgS9QQPddVX7d9hWYswzlf4bIyUD2dj8GC46R1uNClZhVAmsdVts4xb2jwp1PbpuiA50Qee1A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/web-bluetooth": "^0.0.21",
+        "@vueuse/metadata": "13.6.0",
+        "@vueuse/shared": "13.6.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "vue": "^3.5.0"
+      }
+    },
+    "node_modules/@vueuse/metadata": {
+      "version": "13.6.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-13.6.0.tgz",
+      "integrity": "sha512-rnIH7JvU7NjrpexTsl2Iwv0V0yAx9cw7+clymjKuLSXG0QMcLD0LDgdNmXic+qL0SGvgSVPEpM9IDO/wqo1vkQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/shared": {
+      "version": "13.6.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-13.6.0.tgz",
+      "integrity": "sha512-pDykCSoS2T3fsQrYqf9SyF0QXWHmcGPQ+qiOVjlYSzlWd9dgppB2bFSM1GgKKkt7uzn0BBMV3IbJsUfHG2+BCg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "vue": "^3.5.0"
       }
     },
     "node_modules/abbrev": {

--- a/StreamAwesome/package.json
+++ b/StreamAwesome/package.json
@@ -16,6 +16,7 @@
     "tidy": "npm run lint && npm run format"
   },
   "dependencies": {
+    "@vueuse/core": "^13.6.0",
     "chroma-js": "^3.1.2",
     "color-namer": "^1.4.0",
     "pinia": "^2.1.7",

--- a/StreamAwesome/src/components/MainSettings.vue
+++ b/StreamAwesome/src/components/MainSettings.vue
@@ -2,14 +2,20 @@
 import IconBrowser from '@/components/browser/IconBrowser.vue'
 import IconCanvas from '@/components/IconCanvas.vue'
 import IconSettings from '@/components/settings/IconSettings.vue'
+import UserUserPresetManager from '@/components/utils/UserPresetManager.vue'
 import { getMatchingGenerator } from '@/logic/generator/generators'
 import { useIconsStore } from '@/stores/icons'
+import type { CustomIcon } from '@/model/customIcon'
 
 const iconStore = useIconsStore()
 
 function downloadIcon() {
   const iconGenerator = getMatchingGenerator(iconStore.currentIcon)
   iconGenerator.saveIcon(iconStore.currentIcon)
+}
+
+function loadPreset(preset: CustomIcon<any>) {
+  Object.assign(iconStore.currentIcon, preset)
 }
 </script>
 
@@ -21,6 +27,12 @@ function downloadIcon() {
         class="mb-5 mt-5 place-self-center md:place-self-auto"
         @download-icon="downloadIcon"
       />
+      <div class="mb-3">
+        <UserUserPresetManager
+            :icon="iconStore.currentIcon"
+            @load-preset="loadPreset"
+        />
+      </div>
       <IconSettings :icon="iconStore.currentIcon" @download-icon="downloadIcon" />
     </div>
     <div class="flex-grow">

--- a/StreamAwesome/src/components/utils/UserPresetManager.vue
+++ b/StreamAwesome/src/components/utils/UserPresetManager.vue
@@ -1,0 +1,161 @@
+<script setup lang="ts">
+import { ref, computed } from 'vue'
+import type { CustomIcon, FontAwesomePreset } from '@/model/customIcon.ts'
+
+interface IconPreset {
+  name: string
+  settings: CustomIcon<any>
+  createdAt: string
+}
+
+const props = defineProps<{
+  icon: CustomIcon<FontAwesomePreset>
+}>()
+
+const emit = defineEmits<{
+  loadPreset: [preset: CustomIcon<FontAwesomePreset>]
+}>()
+
+const showSaveDialog = ref(false)
+const showLoadDialog = ref(false)
+const presetName = ref('')
+
+const savedPresets = computed(() => {
+  const presets = localStorage.getItem('iconPresets')
+  return presets ? JSON.parse(presets) as IconPreset[] : []
+})
+
+function savePreset() {
+  if (!presetName.value.trim()) {
+    alert('Enter a preset name')
+    return
+  }
+
+  const newPreset: IconPreset = {
+    name: presetName.value.trim(),
+    settings: JSON.parse(JSON.stringify(props.icon)),
+    createdAt: new Date().toISOString()
+  }
+
+  const existingPresets = savedPresets.value
+  const updatedPresets = [...existingPresets, newPreset]
+  localStorage.setItem('iconPresets', JSON.stringify(updatedPresets))
+
+  showSaveDialog.value = false
+  presetName.value = ''
+}
+
+function loadPreset(preset: IconPreset) {
+  emit('loadPreset', preset.settings)
+  showLoadDialog.value = false
+}
+
+function deletePreset(index: number) {
+  if (confirm('Are you sure you want to delete this preset?')) {
+    const existingPresets = savedPresets.value
+    existingPresets.splice(index, 1)
+    localStorage.setItem('iconPresets', JSON.stringify(existingPresets))
+  }
+}
+
+function openSaveDialog() {
+  showSaveDialog.value = true
+  presetName.value = ''
+}
+</script>
+
+<template>
+  <div class="preset-manager flex gap-2">
+    <button
+        @click="openSaveDialog"
+        class="w-full rounded bg-blue-500 px-3 py-1 text-sm text-white hover:bg-blue-600"
+    >
+      Save Preset
+    </button>
+
+    <button
+        :disabled="savedPresets.length === 0"
+        @click="showLoadDialog = true"
+        class="w-full rounded bg-green-600 px-3 py-1 text-sm text-white hover:bg-green-700 disabled:bg-gray-500 disabled:cursor-not-allowed"
+    >
+      Load Preset ({{ savedPresets.length }})
+    </button>
+
+    <div
+        v-if="showSaveDialog"
+        class="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50 rounded-lg"
+    >
+      <div class="rounded bg-gray-800 p-6 shadow-lg">
+        <h3 class="mb-4 text-lg font-semibold">Save Icon Preset</h3>
+        <input
+            v-model="presetName"
+            type="text"
+            placeholder="Enter preset name..."
+            class="mb-4 block w-full rounded-lg border border-gray-300 bg-gray-50 p-2.5 text-sm text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder-gray-400 px-3 py-2"
+            @keyup.enter="savePreset"
+            @keyup.esc="showSaveDialog = false"
+        />
+        <div class="flex gap-2">
+          <button
+              @click="savePreset"
+              class="w-full rounded bg-blue-500 px-4 py-2 text-white hover:bg-blue-600"
+          >
+            Save
+          </button>
+          <button
+              @click="showSaveDialog = false"
+              class="w-full rounded bg-gray-500 px-4 py-2 hover:bg-gray-600"
+          >
+            Cancel
+          </button>
+        </div>
+      </div>
+    </div>
+
+    <div
+        v-if="showLoadDialog"
+        class="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50"
+        @keyup.esc="showLoadDialog = false"
+    >
+      <div class="max-h-[90%] min-w-96 max-w-[80%] overflow-y-auto rounded-lg bg-gray-800 p-6 shadow-lg">
+        <h3 class="mb-4 text-lg font-semibold">Load Icon Preset</h3>
+        <div class="space-y-2">
+          <div
+              v-for="(preset, index) in savedPresets"
+              :key="index"
+              class="flex items-center justify-between rounded border p-3 border-gray-600"
+          >
+            <div>
+              <div class="font-medium">{{ preset.name }}</div>
+              <div class="text-sm text-gray-500">
+                {{ new Date(preset.createdAt).toLocaleString() }}
+              </div>
+            </div>
+            <div class="flex gap-1.5">
+              <button
+                  @click="loadPreset(preset)"
+                  class="rounded bg-green-600 px-2 py-1 text-sm text-white hover:bg-green-700"
+              >
+                Load
+              </button>
+              <button
+                  @click="deletePreset(index)"
+                  class="rounded bg-red-500 px-2 py-1 text-sm text-white hover:bg-red-600"
+              >
+                Delete
+              </button>
+            </div>
+          </div>
+        </div>
+        <div class="mt-4">
+          <button
+              @click="showLoadDialog = false"
+              class="w-full rounded bg-gray-500 px-4 py-2 hover:bg-gray-600"
+          >
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>

--- a/StreamAwesome/src/components/utils/UserPresetManager.vue
+++ b/StreamAwesome/src/components/utils/UserPresetManager.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref, computed } from 'vue'
+import { useStorage } from '@vueuse/core'
 import type { CustomIcon, FontAwesomePreset } from '@/model/customIcon.ts'
 
 interface IconPreset {
@@ -20,10 +21,8 @@ const showSaveDialog = ref(false)
 const showLoadDialog = ref(false)
 const presetName = ref('')
 
-const savedPresets = computed(() => {
-  const presets = localStorage.getItem('iconPresets')
-  return presets ? JSON.parse(presets) as IconPreset[] : []
-})
+const savedPresets = useStorage<IconPreset[]>('iconPresets', [])
+const presetsList = computed(() => savedPresets.value)
 
 function savePreset() {
   if (!presetName.value.trim()) {
@@ -37,9 +36,7 @@ function savePreset() {
     createdAt: new Date().toISOString()
   }
 
-  const existingPresets = savedPresets.value
-  const updatedPresets = [...existingPresets, newPreset]
-  localStorage.setItem('iconPresets', JSON.stringify(updatedPresets))
+  savedPresets.value = [...savedPresets.value, newPreset]
 
   showSaveDialog.value = false
   presetName.value = ''
@@ -52,9 +49,7 @@ function loadPreset(preset: IconPreset) {
 
 function deletePreset(index: number) {
   if (confirm('Are you sure you want to delete this preset?')) {
-    const existingPresets = savedPresets.value
-    existingPresets.splice(index, 1)
-    localStorage.setItem('iconPresets', JSON.stringify(existingPresets))
+    savedPresets.value.splice(index, 1)
   }
 }
 
@@ -74,11 +69,11 @@ function openSaveDialog() {
     </button>
 
     <button
-        :disabled="savedPresets.length === 0"
+        :disabled="presetsList.length === 0"
         @click="showLoadDialog = true"
         class="w-full rounded bg-green-600 px-3 py-1 text-sm text-white hover:bg-green-700 disabled:bg-gray-500 disabled:cursor-not-allowed"
     >
-      Load Preset ({{ savedPresets.length }})
+      Load Preset ({{ presetsList.length }})
     </button>
 
     <div
@@ -121,7 +116,7 @@ function openSaveDialog() {
         <h3 class="mb-4 text-lg font-semibold">Load Icon Preset</h3>
         <div class="space-y-2">
           <div
-              v-for="(preset, index) in savedPresets"
+              v-for="(preset, index) in presetsList"
               :key="index"
               class="flex items-center justify-between rounded border p-3 border-gray-600"
           >


### PR DESCRIPTION
This pull request adds the basic functionality for saving and loading custom setting presets. Presets will be stored in `localStorage` with key `iconPresets` as JSON. 

There are two buttons for opening dialogs for more actions:
<img width="287" height="331" alt="image" src="https://github.com/user-attachments/assets/b59b791c-c8ff-4f1c-9c5f-952d2c684084" />

The loading button would be grayed out when no preset is existing. The number in the brackets shows the amount of available presets.

There's a dialog when saving:
<img width="920" height="999" alt="image" src="https://github.com/user-attachments/assets/eb4cc240-e23b-459a-ad8f-e995fca560e2" />

There's a dialog when loading:
<img width="915" height="1004" alt="image" src="https://github.com/user-attachments/assets/1ab96f76-851f-449c-a77a-61d26a577371" />

Related issue: https://github.com/sebinside/StreamAwesome/issues/283

## Known issue
- When loading a preset, the components will not be displayed correctly -> needs reloading in `PresetOptions.vue`

All in all, this pull request really adds just a starting point for the preset settings.