### PR TITLE
refactor: replace `reactive()` with `ref()`

### DIFF
--- a/StreamAwesome/src/components/settings/GeneralOptions.vue
+++ b/StreamAwesome/src/components/settings/GeneralOptions.vue
@@ -11,13 +11,13 @@ import {
 import { FontAwesomeIconType } from '@/model/fontAwesomeIconType'
 import Icon from '@/components/utils/IconDisplay.vue'
 import type { FontAwesomeIcon } from '@/model/fontAwesomeIcon'
-import { reactive } from 'vue'
+import { ref } from 'vue'
 
 const props = defineProps<{
   icon: CustomIcon<FontAwesomePreset>
 }>()
 
-const currentIcon = reactive(props.icon ?? ({} as CustomIcon<FontAwesomePreset>))
+const currentIcon = ref(props.icon ?? ({} as CustomIcon<FontAwesomePreset>))
 
 const relevantFamilies = Object.values(FontAwesomeFamilyKeys)
 const relevantStyles = Object.values(FontAwesomeStyleKeys).filter((key) => {
@@ -70,15 +70,15 @@ function createFontAwesomeIconDisplayFromFamily(family: FontAwesomeFamily): Font
 
 function updateSize(event: Event) {
   const size = +(event.target as HTMLInputElement).value
-  currentIcon.fontSize = size
+  currentIcon.value.fontSize = size
 }
 
 function updateFamily(family: FontAwesomeFamily) {
-  currentIcon.fontAwesomeIcon.family = family
+  currentIcon.value.fontAwesomeIcon.family = family
 }
 
 function updateStyle(style: FontAwesomeStyle) {
-  currentIcon.fontAwesomeIcon.style = style
+  currentIcon.value.fontAwesomeIcon.style = style
 }
 </script>
 
@@ -120,9 +120,7 @@ function updateStyle(style: FontAwesomeStyle) {
           }"
           class="block cursor-pointer border border-gray-200 bg-white px-4 py-2 text-center text-2xl text-gray-900 select-none peer-checked:border-blue-600 peer-checked:text-blue-600 hover:bg-gray-100 hover:text-gray-600 focus:z-10 dark:border-gray-700 dark:bg-gray-800 dark:text-white dark:peer-checked:text-blue-500 dark:hover:bg-gray-700 dark:hover:text-gray-300"
         >
-          <Icon
-            :fontAwesomeIcon="createFontAwesomeIconDisplayFromFamily(family)"
-          />
+          <Icon :fontAwesomeIcon="createFontAwesomeIconDisplayFromFamily(family)" />
         </label>
       </div>
     </div>
@@ -151,9 +149,7 @@ function updateStyle(style: FontAwesomeStyle) {
             }"
             class="block cursor-pointer border border-gray-200 bg-white px-4 py-2 text-center text-2xl text-gray-900 select-none peer-checked:border-blue-600 peer-checked:text-blue-600 hover:bg-gray-100 hover:text-gray-600 focus:z-10 dark:border-gray-700 dark:bg-gray-800 dark:text-white dark:peer-checked:text-blue-500 dark:hover:bg-gray-700 dark:hover:text-gray-300"
           >
-            <Icon
-              :fontAwesomeIcon="createFontAwesomeIconDisplayFromStyle(style)"
-            />
+            <Icon :fontAwesomeIcon="createFontAwesomeIconDisplayFromStyle(style)" />
           </label>
         </div>
       </div>

--- a/StreamAwesome/src/components/settings/presets/ClassicPreset.vue
+++ b/StreamAwesome/src/components/settings/presets/ClassicPreset.vue
@@ -1,20 +1,20 @@
 <script setup lang="ts">
-import { reactive, ref } from 'vue'
+import { ref } from 'vue'
 import type { CustomIcon, FontAwesomePreset } from '@/model/customIcon'
 
 const props = defineProps<{
   icon: CustomIcon<FontAwesomePreset>
 }>()
 
-const currentIcon = reactive(props.icon ?? ({} as CustomIcon<FontAwesomePreset>))
-currentIcon.presetSettings = {
+const currentIcon = ref(props.icon ?? ({} as CustomIcon<FontAwesomePreset>))
+currentIcon.value.presetSettings = {
   preset: 'Classic',
   hue: 217
 }
-currentIcon.fontAwesomeIcon.style = 'solid'
-currentIcon.fontAwesomeIcon.family = 'classic'
+currentIcon.value.fontAwesomeIcon.style = 'solid'
+currentIcon.value.fontAwesomeIcon.family = 'classic'
 
-const currentHue = ref(currentIcon.presetSettings.hue)
+const currentHue = ref(currentIcon.value.presetSettings.hue)
 </script>
 
 <template>

--- a/StreamAwesome/src/components/settings/presets/CustomPreset.vue
+++ b/StreamAwesome/src/components/settings/presets/CustomPreset.vue
@@ -1,19 +1,19 @@
 <script setup lang="ts">
-import { reactive } from 'vue'
+import { ref } from 'vue'
 import type { CustomIcon, FontAwesomePreset } from '@/model/customIcon'
 
 const props = defineProps<{
   icon: CustomIcon<FontAwesomePreset>
 }>()
 
-const currentIcon = reactive(props.icon ?? ({} as CustomIcon<FontAwesomePreset>))
-currentIcon.presetSettings = {
+const currentIcon = ref(props.icon ?? ({} as CustomIcon<FontAwesomePreset>))
+currentIcon.value.presetSettings = {
   preset: 'Custom',
   backgroundColor: '#111111',
   foregroundColor: '#FFAB00'
 }
-currentIcon.fontAwesomeIcon.style = 'solid'
-currentIcon.fontAwesomeIcon.family = 'duotone'
+currentIcon.value.fontAwesomeIcon.style = 'solid'
+currentIcon.value.fontAwesomeIcon.family = 'duotone'
 </script>
 
 <template>

--- a/StreamAwesome/src/components/settings/presets/ModernPreset.vue
+++ b/StreamAwesome/src/components/settings/presets/ModernPreset.vue
@@ -1,18 +1,18 @@
 <script setup lang="ts">
-import { reactive } from 'vue'
+import { ref } from 'vue'
 import type { CustomIcon, FontAwesomePreset } from '@/model/customIcon'
 
 const props = defineProps<{
   icon: CustomIcon<FontAwesomePreset>
 }>()
 
-const currentIcon = reactive(props.icon ?? ({} as CustomIcon<FontAwesomePreset>))
-currentIcon.presetSettings = {
+const currentIcon = ref(props.icon ?? ({} as CustomIcon<FontAwesomePreset>))
+currentIcon.value.presetSettings = {
   preset: 'Modern',
   inverted: false
 }
-currentIcon.fontAwesomeIcon.style = 'thin'
-currentIcon.fontAwesomeIcon.family = 'sharp'
+currentIcon.value.fontAwesomeIcon.style = 'thin'
+currentIcon.value.fontAwesomeIcon.family = 'sharp'
 </script>
 
 <template>

--- a/StreamAwesome/src/components/settings/presets/NeoPreset.vue
+++ b/StreamAwesome/src/components/settings/presets/NeoPreset.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { reactive, ref } from 'vue'
+import { ref } from 'vue'
 import type { CustomIcon, FontAwesomePreset } from '@/model/customIcon'
 import { ColorSpaceKeys } from '@/model/customIcon'
 
@@ -7,8 +7,8 @@ const props = defineProps<{
   icon: CustomIcon<FontAwesomePreset>
 }>()
 
-const currentIcon = reactive(props.icon ?? ({} as CustomIcon<FontAwesomePreset>))
-currentIcon.presetSettings = {
+const currentIcon = ref(props.icon ?? ({} as CustomIcon<FontAwesomePreset>))
+currentIcon.value.presetSettings = {
   preset: 'Neo',
   colorSpace: 'lch',
   hueStart: 300,
@@ -19,10 +19,10 @@ currentIcon.presetSettings = {
   symbolOnly: false,
   translation: 0
 }
-currentIcon.fontAwesomeIcon.style = 'solid'
-currentIcon.fontAwesomeIcon.family = 'classic'
+currentIcon.value.fontAwesomeIcon.style = 'solid'
+currentIcon.value.fontAwesomeIcon.family = 'classic'
 
-const currentHue = ref(currentIcon.presetSettings.hueStart)
+const currentHue = ref(currentIcon.value.presetSettings.hueStart)
 
 const settingsExpanded = ref(false)
 const toggleSettings = () => {

--- a/StreamAwesome/src/stores/icons.ts
+++ b/StreamAwesome/src/stores/icons.ts
@@ -1,9 +1,9 @@
-import { reactive } from 'vue'
+import { ref } from 'vue'
 import { defineStore } from 'pinia'
 import type { CustomIcon } from '@/model/customIcon'
 
 export const useIconsStore = defineStore('icons', () => {
-  const currentIcon: CustomIcon<'Neo'> = reactive({
+  const currentIcon = ref<CustomIcon<'Neo'>>({
     presetSettings: {
       preset: 'Neo',
       colorSpace: 'lch',


### PR DESCRIPTION
Replace `reactive()` with `ref()`.

Vue suggest to always use `ref()` because `reactive()` has some limitations.
Managing reactivity is also easier with `ref()`.