### PR TITLE
refactor: use `useTemplateRef()` instead of normal `ref()`

### DIFF
--- a/StreamAwesome/src/components/IconCanvas.vue
+++ b/StreamAwesome/src/components/IconCanvas.vue
@@ -1,11 +1,11 @@
 <script setup lang="ts">
 import type { CustomIcon, FontAwesomePreset } from '@/model/customIcon'
-import { onMounted, ref, watch } from 'vue'
+import { onMounted, useTemplateRef, watch } from 'vue'
 import { useFontsStatusStore } from '@/stores/fontStatus'
 import { getMatchingGenerator } from '@/logic/generator/generators'
 
 const fontStatusStore = useFontsStatusStore()
-const iconCanvas = ref<HTMLCanvasElement | null>(null)
+const iconCanvas = useTemplateRef('iconCanvas')
 const props = defineProps<{
   icon: CustomIcon<FontAwesomePreset>
 }>()


### PR DESCRIPTION
Vue `3.5` added a better way to access template refs.

The new `useTemplateRef()` function automatically infers the HTML element's type.