### PR TITLE
Fix options for Font Awesome Free

### DIFF
--- a/StreamAwesome/fonts/.gitignore
+++ b/StreamAwesome/fonts/.gitignore
@@ -1,3 +1,9 @@
 fontawesome/
 fontawesome/css
 fontawesome/webfonts
+fontawesome_free/
+fontawesome_free/css
+fontawesome_free/webfonts
+fontawesome_pro/
+fontawesome_pro/css
+fontawesome_pro/webfonts

--- a/StreamAwesome/src/App.vue
+++ b/StreamAwesome/src/App.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
-import { useFontLoader } from '@/composables/useFontLoader.ts'
-
-useFontLoader()
+import { watchFontLoading } from './utils/watchFontLoading'
+watchFontLoading()
 </script>
 
 <template>

--- a/StreamAwesome/src/components/settings/GeneralOptions.vue
+++ b/StreamAwesome/src/components/settings/GeneralOptions.vue
@@ -5,13 +5,16 @@ import {
   DuotoneKeyword,
   FontAwesomeFamilyKeys,
   FontAwesomeStyleKeys,
+  FontAwesomeFreeFamilyKeys,
   type FontAwesomeFamily,
-  type FontAwesomeStyle
+  type FontAwesomeStyle,
+  FontAwesomeFreeStyleKeys
 } from '@/model/fontAwesomeConstants'
 import { FontAwesomeIconType } from '@/model/fontAwesomeIconType'
 import Icon from '@/components/utils/IconDisplay.vue'
 import type { FontAwesomeIcon } from '@/model/fontAwesomeIcon'
 import { ref } from 'vue'
+import { fontAwesomeVersionInfo } from '@/model/versions'
 
 const props = defineProps<{
   icon: CustomIcon<FontAwesomePreset>
@@ -19,10 +22,16 @@ const props = defineProps<{
 
 const currentIcon = ref(props.icon ?? ({} as CustomIcon<FontAwesomePreset>))
 
-const relevantFamilies = Object.values(FontAwesomeFamilyKeys)
-const relevantStyles = Object.values(FontAwesomeStyleKeys).filter((key) => {
-  return key !== BrandsKeyword
-})
+const relevantFamilies =
+  fontAwesomeVersionInfo.fontLicense === 'Pro'
+    ? Object.values(FontAwesomeFamilyKeys)
+    : Object.values(FontAwesomeFreeFamilyKeys)
+const relevantStyles =
+  fontAwesomeVersionInfo.fontLicense === 'Pro'
+    ? Object.values(FontAwesomeStyleKeys).filter((key) => {
+        return key !== BrandsKeyword
+      })
+    : Object.values(FontAwesomeFreeStyleKeys)
 
 function createFontAwesomeIconDisplayFromStyle(style: FontAwesomeStyle): FontAwesomeIcon {
   if (props.icon === undefined) {

--- a/StreamAwesome/src/main.ts
+++ b/StreamAwesome/src/main.ts
@@ -10,9 +10,7 @@ import { loadFontAwesomeStyles } from '@/utils/initFontAwesome'
   await loadFontAwesomeStyles()
 
   const app = createApp(App)
-
   app.use(createPinia())
   app.use(router)
-
   app.mount('#app')
 })()

--- a/StreamAwesome/src/model/fontAwesomeConstants.ts
+++ b/StreamAwesome/src/model/fontAwesomeConstants.ts
@@ -11,6 +11,10 @@ export const FontFamilySuffixKeys = [
 export const BrandsKeyword = 'brands'
 export const DuotoneKeyword = 'duotone'
 
+// FA Free only contains *some* regular icons, which is not reliable. Thus, they are also excluded.
+export const FontAwesomeFreeStyleKeys = FontAwesomeStyleKeys.slice(0, 1)
+export const FontAwesomeFreeFamilyKeys = FontAwesomeFamilyKeys.slice(0, 1)
+
 export type FontAwesomeFamily = (typeof FontAwesomeFamilyKeys)[number]
 export type FontAwesomeStyle = (typeof FontAwesomeStyleKeys)[number]
 export type FontFamilySuffix = (typeof FontFamilySuffixKeys)[number]

--- a/StreamAwesome/src/utils/watchFontLoading.ts
+++ b/StreamAwesome/src/utils/watchFontLoading.ts
@@ -1,7 +1,7 @@
 import { useFontsStatusStore } from '@/stores/fontStatus'
 import { onMounted } from 'vue'
 
-export function useFontLoader() {
+export function watchFontLoading() {
   // Cross-browser waiting for font loading is messed up, see: https://stackoverflow.com/questions/5680013/how-to-be-notified-once-a-web-font-has-loaded/77481922#77481922
   const waitForFontsLoaded = document.fonts?.ready.then(() => {
     return new Promise((resolve) => {


### PR DESCRIPTION
This PR fixes the displayed options when using Font Awesome Free, addressing issue #332.

<img width="285" height="318" alt="image" src="https://github.com/user-attachments/assets/a1a8b87e-38e8-47cf-a8ca-fc0498fa13a3" />
<img width="278" height="315" alt="image" src="https://github.com/user-attachments/assets/08cb0669-27a5-4e84-8069-800df977d833" />