### PR TITLE
feat: validate Font Awesome API response

### DIFF
--- a/StreamAwesome/package-lock.json
+++ b/StreamAwesome/package-lock.json
@@ -11,6 +11,7 @@
         "chroma-js": "^3.1.2",
         "color-namer": "^1.4.0",
         "pinia": "^3.0.3",
+        "valibot": "^1.1.0",
         "vue": "^3.5.17",
         "vue-router": "^4.4.0"
       },
@@ -7420,6 +7421,20 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
     },
+    "node_modules/valibot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.1.0.tgz",
+      "integrity": "sha512-Nk8lX30Qhu+9txPYTwM0cFlWLdPFsFr6LblzqIySfbZph9+BFsAHsNvHOymEviUepeIW6KFHzpX8TKhbptBXXw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "typescript": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/validate-npm-package-license": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
@@ -12967,6 +12982,12 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
+    },
+    "valibot": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/valibot/-/valibot-1.1.0.tgz",
+      "integrity": "sha512-Nk8lX30Qhu+9txPYTwM0cFlWLdPFsFr6LblzqIySfbZph9+BFsAHsNvHOymEviUepeIW6KFHzpX8TKhbptBXXw==",
+      "requires": {}
     },
     "validate-npm-package-license": {
       "version": "3.0.4",

--- a/StreamAwesome/package.json
+++ b/StreamAwesome/package.json
@@ -19,6 +19,7 @@
     "chroma-js": "^3.1.2",
     "color-namer": "^1.4.0",
     "pinia": "^3.0.3",
+    "valibot": "^1.1.0",
     "vue": "^3.5.17",
     "vue-router": "^4.4.0"
   },

--- a/StreamAwesome/src/components/settings/GeneralOptions.vue
+++ b/StreamAwesome/src/components/settings/GeneralOptions.vue
@@ -1,16 +1,15 @@
 <script setup lang="ts">
 import type { CustomIcon, FontAwesomePreset } from '@/model/customIcon'
 import {
-  BrandsKeyword,
-  DuotoneKeyword,
   FontAwesomeFamilyKeys,
   FontAwesomeStyleKeys,
-  type FontAwesomeFamily,
-  type FontAwesomeStyle
+  BrandsKeyword,
+  DuotoneKeyword
 } from '@/model/fontAwesomeConstants'
 import { FontAwesomeIconType } from '@/model/fontAwesomeIconType'
 import Icon from '@/components/utils/IconDisplay.vue'
 import type { FontAwesomeIcon } from '@/model/fontAwesomeIcon'
+import { type FontAwesomeFamily, type FontAwesomeStyle } from '@/model/fontAwesomeApi.ts'
 import { ref } from 'vue'
 
 const props = defineProps<{
@@ -19,10 +18,8 @@ const props = defineProps<{
 
 const currentIcon = ref(props.icon ?? ({} as CustomIcon<FontAwesomePreset>))
 
-const relevantFamilies = Object.values(FontAwesomeFamilyKeys)
-const relevantStyles = Object.values(FontAwesomeStyleKeys).filter((key) => {
-  return key !== BrandsKeyword
-})
+const relevantFamilies = FontAwesomeFamilyKeys
+const relevantStyles = FontAwesomeStyleKeys.filter((key) => key !== BrandsKeyword)
 
 function createFontAwesomeIconDisplayFromStyle(style: FontAwesomeStyle): FontAwesomeIcon {
   if (props.icon === undefined) {

--- a/StreamAwesome/src/model/fontAwesomeApi.ts
+++ b/StreamAwesome/src/model/fontAwesomeApi.ts
@@ -1,0 +1,33 @@
+import * as v from 'valibot'
+import { FontAwesomeFamilyKeys, FontAwesomeStyleKeys } from '@/model/fontAwesomeConstants.ts'
+
+const FontAwesomeFamilySchema = v.picklist(FontAwesomeFamilyKeys)
+const FontAwesomeStyleSchema = v.picklist(FontAwesomeStyleKeys)
+const FontAwesomeFamilyStylesSchema = v.array(
+  v.object({
+    family: FontAwesomeFamilySchema,
+    style: FontAwesomeStyleSchema
+  })
+)
+const FontAwesomeIconSchema = v.object({
+  id: v.string(),
+  label: v.string(),
+  unicode: v.string(),
+  familyStylesByLicense: v.object({
+    free: FontAwesomeFamilyStylesSchema,
+    pro: FontAwesomeFamilyStylesSchema
+  })
+})
+const FontAwesomeApiResponseSchema = v.object({
+  data: v.object({
+    search: v.array(FontAwesomeIconSchema)
+  })
+})
+export const FontAwesomeIconsSchema = v.pipe(
+  FontAwesomeApiResponseSchema,
+  v.transform((input) => input.data.search)
+)
+
+export type FontAwesomeFamily = v.InferOutput<typeof FontAwesomeFamilySchema>
+export type FontAwesomeStyle = v.InferOutput<typeof FontAwesomeStyleSchema>
+export type FontAwesomeIcon = v.InferOutput<typeof FontAwesomeIconSchema>

--- a/StreamAwesome/src/model/fontAwesomeConstants.ts
+++ b/StreamAwesome/src/model/fontAwesomeConstants.ts
@@ -11,7 +11,5 @@ export const FontFamilySuffixKeys = [
 export const BrandsKeyword = 'brands'
 export const DuotoneKeyword = 'duotone'
 
-export type FontAwesomeFamily = (typeof FontAwesomeFamilyKeys)[number]
-export type FontAwesomeStyle = (typeof FontAwesomeStyleKeys)[number]
 export type FontFamilySuffix = (typeof FontFamilySuffixKeys)[number]
 export type FontWeight = 100 | 300 | 400 | 900

--- a/StreamAwesome/src/model/fontAwesomeIcon.ts
+++ b/StreamAwesome/src/model/fontAwesomeIcon.ts
@@ -1,4 +1,4 @@
-import type { FontAwesomeFamily, FontAwesomeStyle } from '@/model/fontAwesomeConstants'
+import type { FontAwesomeStyle, FontAwesomeFamily } from '@/model/fontAwesomeApi.ts'
 
 export interface FontAwesomeIcon {
   id: string

--- a/StreamAwesome/src/model/fontAwesomeIconType.ts
+++ b/StreamAwesome/src/model/fontAwesomeIconType.ts
@@ -1,12 +1,7 @@
-import {
-  BrandsKeyword,
-  type FontAwesomeFamily,
-  type FontAwesomeStyle,
-  type FontFamilySuffix,
-  type FontWeight
-} from '@/model/fontAwesomeConstants'
+import { BrandsKeyword, type FontFamilySuffix, type FontWeight } from '@/model/fontAwesomeConstants'
 import type { FontAwesomeIcon } from '@/model/fontAwesomeIcon'
 import { fontAwesomeVersionInfo } from '@/model/versions'
+import type { FontAwesomeFamily, FontAwesomeStyle } from '@/model/fontAwesomeApi.ts'
 
 export class FontAwesomeIconType {
   constructor(


### PR DESCRIPTION
Currently, we are lying to TypeScript by using a type cast for the Font Awesome API response in `fontAwesomeBrowser.ts`:

```ts
const json = (await response.json()) as FontAwesomeResponse
```

It's not guaranteed that the `FontAwesomeResponse` type matches the actual Font Awesome API response data.
That's why this PR validates the API response to guarantee that the response data is correct and has a proper type. If the validation fails for whatever reason, you will catch it early. Without a validation everything looks correct because of the type cast but you could run into bugs during runtime.

It's easier and safer to use a validation library for this kind of validation.
For a very basic validation like `typeof exampleData === 'string'`, a validation library is not necessarily needed, but for more complex data (like the Font Awesome API response) a validation library makes much sense.

I'm using the popular validation library **Valibot** here. Technically you can use any other validation library like **Zod** for example. I'm always using Valibot in my own projects because it's a very lightweight and tree-shakeable library and the creator of Valibot was a fellow student of mine. I think it's a great choice for this project.

This PR probably seems complex at first but it's very easy to use.
That's because the validation schemes act like a **single source of truth**.
You just need to define the validation schemes once and the types are automatically derived/inferred.
That means the schemes and the types are always in sync and can be used anywhere in the app.

Here is a summary of how it works:

1. Define the validation schema:

```ts
import * as v from 'valibot' // Tree-shakeable import

const FontAwesomeIconsSchema = v.object({
  // Font Awesome data structure here
});
```

2. Infer type from validation schema. No need to create the types manually:

```ts
export type FontAwesomeIcon = v.InferOutput<typeof FontAwesomeIconSchema>
// Use the FontAwesomeIcon type anywhere in the app
```

3. Validate unknown data:

```ts
const result = v.safeParse(FontAwesomeIconsSchema, fontAwesomeApiResponse)

if (!result.success) {
  // Handle the failed validation here
  return
}

const fontAwesomeIcons = result.output // fontAwesomeIcons is guaranteed to have the correct data and type
```

Only the `getAvailableIcons()` function in `fontAwesomeBrowser.ts` did change slightly but the rest of the app works exactly the same.

That's the Valibot documentation if you want to learn more: https://valibot.dev
However, you don't need to deal with the Valibot code because the `getAvailableIcons()` function is still returning the same data (but in a safer way).

Let me know if you have questions or if you want to change something.