### PR TITLE
Move from yarn to npm in github actions.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,5 +32,5 @@ jobs:
       - name: Install and Build 🔧
         working-directory: StreamAwesome
         run: |
-          yarn install
-          yarn run build
+          npm install
+          npm run build

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,8 +28,8 @@ jobs:
       - name: Install and Build 🔧
         working-directory: StreamAwesome
         run: |
-          yarn install
-          yarn run build
+          npm install
+          npm run build
 
       - name: Deploy 🚀
         uses: burnett01/rsync-deployments@4.1


### PR DESCRIPTION
Going back to npm after the quick fix introduced in https://github.com/sebinside/StreamAwesome/commit/eec9ad81e3837b91f3141720d4d715720e96fcfb, see #346.