### PR TITLE
refactor: simplify icon canvas updates

### DIFF
--- a/StreamAwesome/src/components/IconCanvas.vue
+++ b/StreamAwesome/src/components/IconCanvas.vue
@@ -1,42 +1,24 @@
 <script setup lang="ts">
-import type { CustomIcon, FontAwesomePreset } from '@/model/customIcon'
-import { onMounted, useTemplateRef, watch } from 'vue'
+import { useTemplateRef, watchEffect } from 'vue'
 import { useFontsStatusStore } from '@/stores/fontStatus'
-import { getMatchingGenerator } from '@/logic/generator/generators'
-
-const fontStatusStore = useFontsStatusStore()
-const iconCanvas = useTemplateRef('iconCanvas')
-const props = defineProps<{
-  icon: CustomIcon<FontAwesomePreset>
-}>()
-
-onMounted(() => {
-  if (iconCanvas.value) {
-    fontStatusStore.waitForFontsLoaded(createGenerator)
-  }
-})
-
-function createGenerator() {
-  if (props.icon && iconCanvas.value) {
-    triggerGenerator(props.icon, iconCanvas.value)
-
-    watch(props.icon, () => {
-      if (props.icon && iconCanvas.value) {
-        triggerGenerator(props.icon, iconCanvas.value)
-      }
-    })
-  }
-}
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function triggerGenerator(icon: CustomIcon<any>, canvas: HTMLCanvasElement) {
-  const iconGenerator = getMatchingGenerator(icon, canvas)
-  iconGenerator.generateIcon(icon)
-}
+import { useIconsStore } from '@/stores/icons.ts'
+import { triggerGenerator } from '@/logic/generator/generators'
 
 defineEmits<{
   downloadIcon: []
 }>()
+
+const iconCanvas = useTemplateRef('iconCanvas')
+const fontStatusStore = useFontsStatusStore()
+const iconsStore = useIconsStore()
+
+watchEffect(() => {
+  const iconCanvasIsInitialized = iconCanvas.value != null && fontStatusStore.fontsLoaded
+
+  if (iconCanvasIsInitialized) {
+    triggerGenerator(iconsStore.currentIcon, iconCanvas.value)
+  }
+})
 </script>
 
 <template>

--- a/StreamAwesome/src/components/MainSettings.vue
+++ b/StreamAwesome/src/components/MainSettings.vue
@@ -29,7 +29,6 @@ whenever(copyShortcut, copyIconToClipboard)
   <div class="flex flex-col md:flex-row">
     <div class="mr-0 grid md:mr-7">
       <IconCanvas
-        :icon="iconStore.currentIcon"
         class="mt-5 mb-5 place-self-center md:place-self-auto"
         @download-icon="downloadIcon"
       />

--- a/StreamAwesome/src/logic/generator/generators.ts
+++ b/StreamAwesome/src/logic/generator/generators.ts
@@ -22,3 +22,9 @@ export function getMatchingGenerator<T extends FontAwesomePreset>(
       throw new Error('Preset not supported')
   }
 }
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function triggerGenerator(icon: CustomIcon<any>, canvas: HTMLCanvasElement) {
+  const iconGenerator = getMatchingGenerator(icon, canvas)
+  iconGenerator.generateIcon(icon)
+}


### PR DESCRIPTION
Simplify the icon canvas updates in `IconCanvas.vue`.

I'm using `watchEffect()` here. It works similar to `watch()` but you don't need to pass in the _source data_ you want to watch.

The `triggerGenerator()` function will be executed only if the icon canvas is initialized and it will be executed whenever the `currentIcon` in the `iconsStore` updates.

---

It's a good practice in Vue to put normal TypeScript functions into normal TypeScript files, so Vue components only need to manage Vue related code.
The awesome side effect is that you can unit-test those TypeScript functions very easily without needing to mount the Vue components.

That's why I moved the `triggerGenerator()` function into the `generators.ts` file next to the `getMatchingGenerator()` function.
The component now only needs to call this function.