### PR TITLE
feat: enhance copyIconButton

### DIFF
--- a/StreamAwesome/src/components/MainSettings.vue
+++ b/StreamAwesome/src/components/MainSettings.vue
@@ -5,7 +5,6 @@ import IconSettings from '@/components/settings/IconSettings.vue'
 import { getMatchingGenerator } from '@/logic/generator/generators'
 import { URLHandler } from '@/logic/URLHandler'
 import { useIconsStore } from '@/stores/icons'
-import { useMagicKeys, whenever } from '@vueuse/core'
 import { useFontsStatusStore } from '@/stores/fontStatus'
 
 const iconStore = useIconsStore()
@@ -15,14 +14,6 @@ function downloadIcon() {
   const iconGenerator = getMatchingGenerator(iconStore.currentIcon)
   iconGenerator.saveIcon(iconStore.currentIcon)
 }
-
-function copyIconToClipboard() {
-  const iconGenerator = getMatchingGenerator(iconStore.currentIcon)
-  iconGenerator.copyIconToClipboard(iconStore.currentIcon)
-}
-
-const copyShortcut = useMagicKeys()['Ctrl+C']
-whenever(copyShortcut, copyIconToClipboard)
 </script>
 
 <template>
@@ -33,11 +24,7 @@ whenever(copyShortcut, copyIconToClipboard)
         class="mt-5 mb-5 place-self-center md:place-self-auto"
         @download-icon="downloadIcon"
       />
-      <IconSettings
-        :icon="iconStore.currentIcon"
-        @download-icon="downloadIcon"
-        @copy-icon-to-clipboard="copyIconToClipboard"
-      />
+      <IconSettings :icon="iconStore.currentIcon" @download-icon="downloadIcon" />
     </div>
     <div class="flex-grow">
       <IconBrowser />

--- a/StreamAwesome/src/components/settings/DownloadButton.vue
+++ b/StreamAwesome/src/components/settings/DownloadButton.vue
@@ -8,8 +8,8 @@ defineEmits<{
 
 const { copyIconToClipboard, iconIsCopiedToClipboard } = useCopyIcon()
 
-const copyShortcut = useMagicKeys()['Ctrl+C']
-whenever(copyShortcut, copyIconToClipboard)
+const copyShortcutIsPressed = useMagicKeys()['Ctrl+C']
+whenever(copyShortcutIsPressed, copyIconToClipboard)
 </script>
 
 <template>

--- a/StreamAwesome/src/components/settings/DownloadButton.vue
+++ b/StreamAwesome/src/components/settings/DownloadButton.vue
@@ -1,8 +1,15 @@
 <script setup lang="ts">
+import { useCopyIcon } from '@/composables/useCopyIcon.ts'
+import { useMagicKeys, whenever } from '@vueuse/core'
+
 defineEmits<{
   downloadIcon: []
-  copyIconToClipboard: []
 }>()
+
+const { copyIconToClipboard, iconIsCopiedToClipboard } = useCopyIcon()
+
+const copyShortcut = useMagicKeys()['Ctrl+C']
+whenever(copyShortcut, copyIconToClipboard)
 </script>
 
 <template>
@@ -17,9 +24,10 @@ defineEmits<{
     <button
       type="button"
       class="mb-2 w-full cursor-pointer rounded-r-lg bg-gradient-to-r from-blue-500 to-purple-500 px-5 py-2.5 text-center text-sm font-medium text-white hover:to-pink-500 focus:ring-2 focus:ring-cyan-300 focus:outline-none dark:focus:ring-cyan-800"
-      @click="$emit('copyIconToClipboard')"
+      @click="copyIconToClipboard"
     >
-      <i class="fa-solid fa-copy"></i> Copy
+      <span v-if="!iconIsCopiedToClipboard"><i class="fa-solid fa-copy"></i> Copy</span>
+      <span v-else>Copied</span>
     </button>
   </div>
 </template>

--- a/StreamAwesome/src/components/settings/IconSettings.vue
+++ b/StreamAwesome/src/components/settings/IconSettings.vue
@@ -9,7 +9,6 @@ defineProps<{
 }>()
 defineEmits<{
   downloadIcon: []
-  copyIconToClipboard: []
 }>()
 </script>
 
@@ -18,8 +17,5 @@ defineEmits<{
 
   <GeneralOptions :icon="icon" />
 
-  <DownloadButton
-    @downloadIcon="$emit('downloadIcon')"
-    @copyIconToClipboard="$emit('copyIconToClipboard')"
-  />
+  <DownloadButton @downloadIcon="$emit('downloadIcon')" />
 </template>

--- a/StreamAwesome/src/composables/useCopyIcon.ts
+++ b/StreamAwesome/src/composables/useCopyIcon.ts
@@ -1,0 +1,25 @@
+import { useClipboardItems } from '@vueuse/core'
+import { useIconsStore } from '@/stores/icons.ts'
+import { getMatchingGenerator } from '@/logic/generator/generators.ts'
+
+export function useCopyIcon() {
+  const iconStore = useIconsStore()
+  const { copy, copied } = useClipboardItems({ copiedDuring: 2_000 })
+
+  async function copyIconToClipboard() {
+    const iconAsClipboardItem = await getIconAsClipboardItem()
+    await copy([iconAsClipboardItem])
+  }
+
+  async function getIconAsClipboardItem() {
+    const iconGenerator = getMatchingGenerator(iconStore.currentIcon)
+    const iconAsBlob = await iconGenerator.getIconAsBlob(iconStore.currentIcon)
+
+    return new ClipboardItem({ 'image/png': iconAsBlob })
+  }
+
+  return {
+    copyIconToClipboard,
+    iconIsCopiedToClipboard: copied
+  }
+}

--- a/StreamAwesome/src/logic/generator/iconGenerator.ts
+++ b/StreamAwesome/src/logic/generator/iconGenerator.ts
@@ -100,17 +100,9 @@ export default abstract class IconGenerator<T extends FontAwesomePreset> {
     linkElement.click()
   }
 
-  copyIconToClipboard(icon: CustomIcon<T>) {
+  getIconAsBlob(icon: CustomIcon<T>) {
     this.prepareIconForExport(icon)
-
-    this.canvas.toBlob((blob) => {
-      if (blob) {
-        const item = new ClipboardItem({ 'image/png': blob })
-        navigator.clipboard
-          .write([item])
-          .catch((e) => console.error('Failed to copy icon to clipboard:', e))
-      }
-    }, 'image/png')
+    return new Promise<Blob>((resolve) => this.canvas.toBlob((blob) => resolve(blob!), 'image/png'))
   }
 
   private generateCustomIconName(icon: CustomIcon<T>): string {


### PR DESCRIPTION
Enhance `copyIconButton`:

* Show a 'Copied' text inside the button when the icon is copied to provide user feedback.<br>It also works when using the copy shortcut.
* Move the copy logic into the composable `useCopyIcon()`.
* The `iconGenerator.ts` now only needs to generate the icon as a blob instead of also handling the copy logic.

The copy logic is now very easy to use.
Just use this line anywhere you need:

```ts
const { copyIconToClipboard, iconIsCopiedToClipboard } = useCopyIcon()
```

https://github.com/user-attachments/assets/34a61be4-be8d-46b4-8f99-e542f4a38802