### PR TITLE
refactor: simplify store usage

### DIFF
--- a/StreamAwesome/src/components/MainSettings.vue
+++ b/StreamAwesome/src/components/MainSettings.vue
@@ -23,7 +23,7 @@ function downloadIcon() {
         class="mt-5 mb-5 place-self-center md:place-self-auto"
         @download-icon="downloadIcon"
       />
-      <IconSettings :icon="iconStore.currentIcon" @download-icon="downloadIcon" />
+      <IconSettings @download-icon="downloadIcon" />
     </div>
     <div class="flex-grow">
       <IconBrowser />

--- a/StreamAwesome/src/components/settings/IconSettings.vue
+++ b/StreamAwesome/src/components/settings/IconSettings.vue
@@ -1,21 +1,20 @@
 <script setup lang="ts">
-import type { CustomIcon, FontAwesomePreset } from '@/model/customIcon'
 import PresetOptions from '@/components/settings/PresetOptions.vue'
 import GeneralOptions from '@/components/settings/GeneralOptions.vue'
 import DownloadButton from '@/components/settings/DownloadButton.vue'
+import { useIconsStore } from '@/stores/icons.ts'
 
-defineProps<{
-  icon: CustomIcon<FontAwesomePreset>
-}>()
 defineEmits<{
   downloadIcon: []
 }>()
+
+const iconStore = useIconsStore()
 </script>
 
 <template>
-  <PresetOptions :icon="icon" />
+  <PresetOptions :icon="iconStore.currentIcon" />
 
-  <GeneralOptions :icon="icon" />
+  <GeneralOptions :icon="iconStore.currentIcon" />
 
   <DownloadButton @downloadIcon="$emit('downloadIcon')" />
 </template>


### PR DESCRIPTION
Use the store directly instead of using props.

When using a store, it's totally fine to import it directly in the components where it's needed.
This avoids "prop-drilling" (passing props through multiple components).

I only moved the store usage one component layer down. I didn't import the store directly in `PresetOptions.vue` and `GeneralOptions.vue` because these components are more complex and it would lead to a bigger code change.