### PR TITLE
feat: make `fontsLoaded` ref `readonly`

### DIFF
--- a/StreamAwesome/src/stores/fontStatus.ts
+++ b/StreamAwesome/src/stores/fontStatus.ts
@@ -1,4 +1,4 @@
-import { ref } from 'vue'
+import { ref, readonly } from 'vue'
 import { defineStore } from 'pinia'
 
 export const useFontsStatusStore = defineStore('fontStatus', () => {
@@ -19,5 +19,9 @@ export const useFontsStatusStore = defineStore('fontStatus', () => {
     }
   }
 
-  return { fontsLoaded, setFontsLoaded, waitForFontsLoaded }
+  return {
+    fontsLoaded: readonly(fontsLoaded),
+    setFontsLoaded,
+    waitForFontsLoaded
+  }
 })


### PR DESCRIPTION
If a `ref` is returned from a store, it can be directly updated from outside.
This is a good thing in general:

```ts
exampleStore.variable = true
exampleStore.variable = false
```

However, this implies that the `fontsLoaded` ref could be accidentally set back to `false` from anywhere.
To prevent this, make the `fontsLoaded` ref `readonly`.

Vue provides this `readonly()` function which can be used to wrap a ref.