### PR TITLE
refactor: simplify `waitForFontsLoaded()`

### DIFF
--- a/StreamAwesome/src/stores/fontStatus.ts
+++ b/StreamAwesome/src/stores/fontStatus.ts
@@ -1,5 +1,6 @@
 import { ref, readonly } from 'vue'
 import { defineStore } from 'pinia'
+import { whenever } from '@vueuse/core'
 
 export const useFontsStatusStore = defineStore('fontStatus', () => {
   const fontsLoaded = ref(false)
@@ -8,15 +9,7 @@ export const useFontsStatusStore = defineStore('fontStatus', () => {
   }
 
   function waitForFontsLoaded(callback: () => void) {
-    if (fontsLoaded.value) {
-      callback()
-    } else {
-      useFontsStatusStore().$subscribe((_, state) => {
-        if (state.fontsLoaded) {
-          callback()
-        }
-      })
-    }
+    whenever(fontsLoaded, callback, { once: true })
   }
 
   return {


### PR DESCRIPTION
Simplify the `waitForFontsLoaded()` function in the `fontStatusStore`.

The callback function will be executed _whenever_ the `fontsLoaded` ref is `true`.
Because it should only be executed once, the `once` option is set to `true`.