### PR TITLE
refactor(preset): simplify `ClassicPreset.vue`

### DIFF
--- a/StreamAwesome/src/components/settings/presets/ClassicPreset.vue
+++ b/StreamAwesome/src/components/settings/presets/ClassicPreset.vue
@@ -1,12 +1,15 @@
 <script setup lang="ts">
-import { ref } from 'vue'
 import type { CustomIcon, FontAwesomePreset } from '@/model/customIcon'
+import { useIconsStore } from '@/stores/icons.ts'
+import { storeToRefs } from 'pinia'
 
-const props = defineProps<{
+defineProps<{
   icon: CustomIcon<FontAwesomePreset>
 }>()
 
-const currentIcon = ref(props.icon ?? ({} as CustomIcon<FontAwesomePreset>))
+const iconStore = useIconsStore()
+const { currentIcon } = storeToRefs(iconStore)
+
 if (currentIcon.value.presetSettings.preset !== 'Classic') {
   applyDefaultSettings()
 }
@@ -19,8 +22,6 @@ function applyDefaultSettings() {
   currentIcon.value.fontAwesomeIcon.style = 'solid'
   currentIcon.value.fontAwesomeIcon.family = 'classic'
 }
-
-const currentHue = ref((currentIcon.value as CustomIcon<'Classic'>).presetSettings.hue)
 </script>
 
 <template>
@@ -34,7 +35,6 @@ const currentHue = ref((currentIcon.value as CustomIcon<'Classic'>).presetSettin
     min="0"
     class="selector focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
     v-model.number="(currentIcon as CustomIcon<'Classic'>).presetSettings.hue"
-    @input="currentHue = (currentIcon as CustomIcon<'Classic'>).presetSettings.hue"
   />
 </template>
 

--- a/StreamAwesome/src/components/settings/presets/ClassicPreset.vue
+++ b/StreamAwesome/src/components/settings/presets/ClassicPreset.vue
@@ -2,6 +2,7 @@
 import type { CustomIcon, FontAwesomePreset } from '@/model/customIcon'
 import { useIconsStore } from '@/stores/icons.ts'
 import { storeToRefs } from 'pinia'
+import { computed } from 'vue'
 
 defineProps<{
   icon: CustomIcon<FontAwesomePreset>
@@ -22,6 +23,8 @@ function applyDefaultSettings() {
   currentIcon.value.fontAwesomeIcon.style = 'solid'
   currentIcon.value.fontAwesomeIcon.family = 'classic'
 }
+
+const currentHue = computed(() => (currentIcon.value as CustomIcon<'Classic'>).presetSettings.hue)
 </script>
 
 <template>


### PR DESCRIPTION
Use the `iconStore` directly instead of using props.

In addition, remove the `@input` event listener because the `hue` updates are already handled by the `v-model`.