### PR TITLE
refactor: simplify styles in `CustomPreset.vue`

### DIFF
--- a/StreamAwesome/src/components/settings/presets/CustomPreset.vue
+++ b/StreamAwesome/src/components/settings/presets/CustomPreset.vue
@@ -26,7 +26,6 @@ function applyDefaultSettings() {
   <label class="inline-flex cursor-pointer items-center">
     <input
       type="color"
-      class="cursor-pointer"
       v-model="(currentIcon as CustomIcon<'Custom'>).presetSettings.foregroundColor"
     />
     <span class="ms-3 text-sm font-medium text-gray-900 dark:text-white">Icon Color</span>
@@ -35,7 +34,6 @@ function applyDefaultSettings() {
   <label class="mt-2 inline-flex cursor-pointer items-center">
     <input
       type="color"
-      class="cursor-pointer"
       v-model="(currentIcon as CustomIcon<'Custom'>).presetSettings.backgroundColor"
     />
     <span class="ms-3 text-sm font-medium text-gray-900 dark:text-white">Background Color</span>
@@ -43,26 +41,23 @@ function applyDefaultSettings() {
 </template>
 
 <style scoped>
-input[type='color'] {
+input {
   border: none;
+  border-radius: 5px;
   padding: 0;
   width: 2rem;
   height: 2rem;
-  -webkit-appearance: none;
-  appearance: none;
-}
-
-input[type='color']::-webkit-color-swatch-wrapper {
-  padding: 0;
-}
-
-input[type='color']::-webkit-color-swatch {
-  border: none;
-}
-
-input[type='color'] {
   cursor: pointer;
-  border-radius: 5px;
   overflow: hidden;
+  appearance: none;
+  -webkit-appearance: none;
+
+  &::-webkit-color-swatch-wrapper {
+    padding: 0;
+  }
+
+  &::-webkit-color-swatch {
+    border: none;
+  }
 }
 </style>


### PR DESCRIPTION
Use CSS nesting to group styles and avoid duplicate CSS selectors.