### PR TITLE
refactor color styles in preset components

### DIFF
--- a/StreamAwesome/src/components/settings/presets/ClassicPreset.vue
+++ b/StreamAwesome/src/components/settings/presets/ClassicPreset.vue
@@ -24,12 +24,12 @@ const currentHue = ref((currentIcon.value as CustomIcon<'Classic'>).presetSettin
 </script>
 
 <template>
-  <label for="hueSelector" class="block flex-grow text-sm font-medium text-gray-900 dark:text-white"
+  <label for="hue" class="block flex-grow text-sm font-medium text-gray-900 dark:text-white"
     >Hue:</label
   >
   <input
     type="range"
-    id="hueSelector"
+    id="hue"
     max="360"
     min="0"
     class="color-range-input focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"

--- a/StreamAwesome/src/components/settings/presets/ClassicPreset.vue
+++ b/StreamAwesome/src/components/settings/presets/ClassicPreset.vue
@@ -32,62 +32,8 @@ const currentHue = ref((currentIcon.value as CustomIcon<'Classic'>).presetSettin
     id="hueSelector"
     max="360"
     min="0"
-    class="selector focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+    class="color-range-input focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
     v-model.number="(currentIcon as CustomIcon<'Classic'>).presetSettings.hue"
     @input="currentHue = (currentIcon as CustomIcon<'Classic'>).presetSettings.hue"
   />
 </template>
-
-<style scoped>
-.selector {
-  display: block;
-  height: 1rem;
-  width: 100%;
-  cursor: pointer;
-  -webkit-appearance: none;
-  appearance: none;
-  border-radius: 0.25rem;
-  outline: 2px solid transparent;
-  outline-offset: 2px;
-}
-
-#hueSelector {
-  background: linear-gradient(
-    90deg,
-    hsl(0, 72%, 56%) 0%,
-    hsl(60, 72%, 56%) 25%,
-    hsl(120, 72%, 56%) 33.3%,
-    hsl(240, 72%, 56%) 66.6%,
-    hsl(360, 72%, 56%) 100%
-  );
-}
-
-#hueSelector::-webkit-slider-thumb {
-  -webkit-appearance: none;
-  width: 20px;
-  height: 20px;
-  border-radius: 9999px;
-  background-color: hsl(v-bind('currentHue'), 72%, 56%);
-  border: 2px solid white;
-  box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.15);
-}
-
-/* ---------- Firefox only ---------- */
-#hueSelector::-moz-range-track {
-  height: 8px;
-  background: transparent;
-  border: none;
-}
-#hueSelector::-moz-range-progress {
-  height: 8px;
-  background: transparent;
-}
-#hueSelector::-moz-range-thumb {
-  width: 20px;
-  height: 20px;
-  border-radius: 9999px;
-  background: hsl(v-bind('currentHue'), 72%, 56%);
-  border: 2px solid white;
-  box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.15);
-}
-</style>

--- a/StreamAwesome/src/components/settings/presets/NeoPreset.vue
+++ b/StreamAwesome/src/components/settings/presets/NeoPreset.vue
@@ -45,7 +45,7 @@ const toggleSettings = () => {
     id="hueSelector"
     min="0"
     max="360"
-    class="selector focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+    class="color-range-input focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
     v-model.number="(currentIcon as CustomIcon<'Neo'>).presetSettings.hueStart"
     @input="currentHue = (currentIcon as CustomIcon<'Neo'>).presetSettings.hueStart"
   />
@@ -124,7 +124,7 @@ const toggleSettings = () => {
       max="1"
       min="0.05"
       step="0.01"
-      class="selector focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+      class="color-range-input focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
       v-model.number="(currentIcon as CustomIcon<'Neo'>).presetSettings.saturation"
     />
 
@@ -139,7 +139,7 @@ const toggleSettings = () => {
       max="0.95"
       min="0.05"
       step="0.01"
-      class="selector focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+      class="color-range-input focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
       v-model.number="(currentIcon as CustomIcon<'Neo'>).presetSettings.lightness"
     />
 
@@ -161,29 +161,6 @@ const toggleSettings = () => {
 </template>
 
 <style scoped>
-.selector {
-  display: block;
-  height: 1rem;
-  width: 100%;
-  cursor: pointer;
-  -webkit-appearance: none;
-  appearance: none;
-  border-radius: 0.25rem;
-  outline: 2px solid transparent;
-  outline-offset: 2px;
-}
-
-#hueSelector {
-  background: linear-gradient(
-    90deg,
-    hsl(0, 72%, 56%) 0%,
-    hsl(60, 72%, 56%) 25%,
-    hsl(120, 72%, 56%) 33.3%,
-    hsl(240, 72%, 56%) 66.6%,
-    hsl(360, 72%, 56%) 100%
-  );
-}
-
 #saturationSelector {
   background: linear-gradient(
     90deg,
@@ -198,34 +175,5 @@ const toggleSettings = () => {
     hsl(v-bind('currentHue'), 72%, 5%) 0%,
     hsl(v-bind('currentHue'), 72%, 95%) 100%
   );
-}
-
-#hueSelector::-webkit-slider-thumb {
-  -webkit-appearance: none;
-  width: 20px;
-  height: 20px;
-  border-radius: 9999px;
-  background-color: hsl(v-bind('currentHue'), 72%, 56%);
-  border: 2px solid white;
-  box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.15);
-}
-
-/* ---------- Firefox only ---------- */
-#hueSelector::-moz-range-track {
-  height: 8px;
-  background: transparent;
-  border: none;
-}
-#hueSelector::-moz-range-progress {
-  height: 8px;
-  background: transparent;
-}
-#hueSelector::-moz-range-thumb {
-  width: 20px;
-  height: 20px;
-  border-radius: 9999px;
-  background: hsl(v-bind('currentHue'), 72%, 56%);
-  border: 2px solid white;
-  box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.15);
 }
 </style>

--- a/StreamAwesome/src/components/settings/presets/NeoPreset.vue
+++ b/StreamAwesome/src/components/settings/presets/NeoPreset.vue
@@ -37,12 +37,12 @@ const toggleSettings = () => {
 </script>
 
 <template>
-  <label for="hueSelector" class="block flex-grow text-sm font-medium text-gray-900 dark:text-white"
+  <label for="hue" class="block flex-grow text-sm font-medium text-gray-900 dark:text-white"
     >Hue Start:</label
   >
   <input
     type="range"
-    id="hueSelector"
+    id="hue"
     min="0"
     max="360"
     class="color-range-input focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
@@ -113,43 +113,39 @@ const toggleSettings = () => {
       v-model.number="(currentIcon as CustomIcon<'Neo'>).presetSettings.translation"
     />
 
-    <label
-      for="saturationSelector"
-      class="mt-2 block text-sm font-medium text-gray-900 dark:text-white"
+    <label for="saturation" class="mt-2 block text-sm font-medium text-gray-900 dark:text-white"
       >Saturation:</label
     >
     <input
       type="range"
-      id="saturationSelector"
+      id="saturation"
       max="1"
       min="0.05"
       step="0.01"
-      class="color-range-input focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+      class="saturation-range-input color-range-input focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
       v-model.number="(currentIcon as CustomIcon<'Neo'>).presetSettings.saturation"
     />
 
-    <label
-      for="lightnessSelector"
-      class="mt-2 block text-sm font-medium text-gray-900 dark:text-white"
+    <label for="lightness" class="mt-2 block text-sm font-medium text-gray-900 dark:text-white"
       >Lightness:</label
     >
     <input
       type="range"
-      id="lightnessSelector"
+      id="lightness"
       max="0.95"
       min="0.05"
       step="0.01"
-      class="color-range-input focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+      class="lightness-range-input color-range-input focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
       v-model.number="(currentIcon as CustomIcon<'Neo'>).presetSettings.lightness"
     />
 
     <label
-      for="colorSpaceSelector"
+      for="colorSpace"
       class="mt-3 mb-2 block text-sm font-medium text-gray-900 dark:text-white"
       >Select Color Space:</label
     >
     <select
-      id="presetselector"
+      id="colorSpace"
       v-model="(currentIcon as CustomIcon<'Neo'>).presetSettings.colorSpace"
       class="mb-6 block w-full rounded-lg border border-gray-300 bg-gray-50 p-2.5 text-sm text-gray-900 focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder-gray-400 dark:focus:border-blue-500 dark:focus:ring-blue-500"
     >
@@ -161,7 +157,7 @@ const toggleSettings = () => {
 </template>
 
 <style scoped>
-#saturationSelector {
+.saturation-range-input {
   background: linear-gradient(
     90deg,
     hsl(v-bind('currentHue'), 5%, 56%) 0%,
@@ -169,7 +165,7 @@ const toggleSettings = () => {
   );
 }
 
-#lightnessSelector {
+.lightness-range-input {
   background: linear-gradient(
     90deg,
     hsl(v-bind('currentHue'), 72%, 5%) 0%,

--- a/StreamAwesome/src/style.css
+++ b/StreamAwesome/src/style.css
@@ -1,1 +1,53 @@
 @import 'tailwindcss';
+
+.color-range-input {
+  display: block;
+  height: 1rem;
+  width: 100%;
+  cursor: pointer;
+  border-radius: 0.25rem;
+  outline: 2px solid transparent;
+  outline-offset: 2px;
+  background: linear-gradient(
+    90deg,
+    hsl(0, 72%, 56%) 0%,
+    hsl(60, 72%, 56%) 25%,
+    hsl(120, 72%, 56%) 33.3%,
+    hsl(240, 72%, 56%) 66.6%,
+    hsl(360, 72%, 56%) 100%
+  );
+  appearance: none;
+  -webkit-appearance: none;
+
+  /* ::-webkit-slider-thumb is supported by all browsers except Firefox */
+  &::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    width: 20px;
+    height: 20px;
+    border-radius: 9999px;
+    background-color: hsl(v-bind('currentHue'), 72%, 56%);
+    border: 2px solid white;
+    box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.15);
+  }
+
+  /* The -moz prefix is only supported by Firefox */
+  &::-moz-range-track {
+    height: 8px;
+    background: transparent;
+    border: none;
+  }
+
+  &::-moz-range-progress {
+    height: 8px;
+    background: transparent;
+  }
+
+  &::-moz-range-thumb {
+    width: 20px;
+    height: 20px;
+    border-radius: 9999px;
+    background: hsl(v-bind('currentHue'), 72%, 56%);
+    border: 2px solid white;
+    box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.15);
+  }
+}


### PR DESCRIPTION
Outsource styles into global `color-range-input` class because `ClassicPreset.vue` and `NeoPreset.vue` had duplicate styles before.
(In my IDE I can do _control + left click_ on the `color-range-input` class to quickly jump to the code.)

In addition, adjust HTML ids.