### PR TITLE
refactor: remove unused props and `iconStore`

### DIFF
--- a/StreamAwesome/src/components/settings/IconSettings.vue
+++ b/StreamAwesome/src/components/settings/IconSettings.vue
@@ -2,9 +2,6 @@
 import PresetOptions from '@/components/settings/PresetOptions.vue'
 import GeneralOptions from '@/components/settings/GeneralOptions.vue'
 import DownloadButton from '@/components/settings/DownloadButton.vue'
-import { useIconsStore } from '@/stores/icons.ts'
-
-const iconStore = useIconsStore()
 </script>
 
 <template>

--- a/StreamAwesome/src/components/settings/PresetOptions.vue
+++ b/StreamAwesome/src/components/settings/PresetOptions.vue
@@ -40,6 +40,6 @@ const selectedPresetComponent = computed(() => presets[selectedPreset.value])
       </option>
     </select>
 
-    <component :is="selectedPresetComponent" :icon="currentIcon" />
+    <component :is="selectedPresetComponent" />
   </div>
 </template>

--- a/StreamAwesome/src/components/settings/presets/ClassicPreset.vue
+++ b/StreamAwesome/src/components/settings/presets/ClassicPreset.vue
@@ -1,12 +1,8 @@
 <script setup lang="ts">
-import type { CustomIcon, FontAwesomePreset } from '@/model/customIcon'
+import type { CustomIcon } from '@/model/customIcon'
 import { useIconsStore } from '@/stores/icons.ts'
 import { storeToRefs } from 'pinia'
 import { computed } from 'vue'
-
-defineProps<{
-  icon: CustomIcon<FontAwesomePreset>
-}>()
 
 const iconStore = useIconsStore()
 const { currentIcon } = storeToRefs(iconStore)

--- a/StreamAwesome/src/components/settings/presets/CustomPreset.vue
+++ b/StreamAwesome/src/components/settings/presets/CustomPreset.vue
@@ -1,11 +1,7 @@
 <script setup lang="ts">
-import type { CustomIcon, FontAwesomePreset } from '@/model/customIcon'
+import type { CustomIcon } from '@/model/customIcon'
 import { useIconsStore } from '@/stores/icons.ts'
 import { storeToRefs } from 'pinia'
-
-defineProps<{
-  icon: CustomIcon<FontAwesomePreset>
-}>()
 
 const iconStore = useIconsStore()
 const { currentIcon } = storeToRefs(iconStore)

--- a/StreamAwesome/src/components/settings/presets/ModernPreset.vue
+++ b/StreamAwesome/src/components/settings/presets/ModernPreset.vue
@@ -1,11 +1,7 @@
 <script setup lang="ts">
-import type { CustomIcon, FontAwesomePreset } from '@/model/customIcon'
+import type { CustomIcon } from '@/model/customIcon'
 import { useIconsStore } from '@/stores/icons.ts'
 import { storeToRefs } from 'pinia'
-
-defineProps<{
-  icon: CustomIcon<FontAwesomePreset>
-}>()
 
 const iconStore = useIconsStore()
 const { currentIcon } = storeToRefs(iconStore)

--- a/StreamAwesome/src/components/settings/presets/NeoPreset.vue
+++ b/StreamAwesome/src/components/settings/presets/NeoPreset.vue
@@ -1,13 +1,9 @@
 <script setup lang="ts">
 import { ref, computed } from 'vue'
-import type { CustomIcon, FontAwesomePreset } from '@/model/customIcon'
+import type { CustomIcon } from '@/model/customIcon'
 import { ColorSpaceKeys } from '@/model/customIcon'
 import { useIconsStore } from '@/stores/icons.ts'
 import { storeToRefs } from 'pinia'
-
-defineProps<{
-  icon: CustomIcon<FontAwesomePreset>
-}>()
 
 const iconStore = useIconsStore()
 const { currentIcon } = storeToRefs(iconStore)


### PR DESCRIPTION
This PR cleans up the old code of the previous PRs.

Remove unused props in preset components and remove unused `iconStore` in `IconSettings.vue`.